### PR TITLE
Added missing libraries (enable CEF support)

### DIFF
--- a/ue4docker/dockerfiles/ue4-full/linux/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-full/linux/Dockerfile
@@ -61,5 +61,14 @@ RUN apt-get install -y --no-install-recommends \
 	x11-xkb-utils \
 	xauth \
 	xfonts-base \
-	xkb-data
+	xkb-data \
+	apt-file \
+	libasound2 \
+	libpangocairo-1.0-0 \
+	libcairo-5c0 \
+	libpango-1.0 \
+	libnss3 \
+	libnspr4 \
+	libatk1.0
+
 USER ue4


### PR DESCRIPTION
Adding these libraries (with the exception of `apt-file`, that I suggest keeping because it is really useful into the container) allow building applications that are using `libcef.so`