### PR TITLE
Use dotnet SDK 4.8

### DIFF
--- a/ue4docker/infrastructure/BuildConfiguration.py
+++ b/ue4docker/infrastructure/BuildConfiguration.py
@@ -177,7 +177,7 @@ class BuildConfiguration(object):
 		
 		# Store the tag for the base Windows Server Core image
 		self.basetag = self.args.basetag if self.args.basetag is not None else self.hostBasetag
-		self.baseImage = 'mcr.microsoft.com/dotnet/framework/sdk:4.7.2-windowsservercore-' + self.basetag
+		self.baseImage = 'mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-' + self.basetag
 		self.prereqsTag = self.basetag
 		
 		# Verify that any user-specified base tag is valid


### PR DESCRIPTION
In this way, we can create the images on Windows server updated with the February 2020 patch.
Fixes https://github.com/adamrehn/ue4-docker/issues/73