### PR TITLE
`diagnostics 8gig` speed and doc improvement

### DIFF
--- a/ue4docker/diagnostics/diagnostic_8gig.py
+++ b/ue4docker/diagnostics/diagnostic_8gig.py
@@ -28,11 +28,11 @@ class diagnostic8Gig(DiagnosticBase):
 		Returns a description of what the diagnostic does
 		'''
 		return '\n'.join([
-			'This diagnostic determines if the Docker daemon suffers from the 8GiB filesystem',
-			'layer bug reported here: https://github.com/moby/moby/issues/37581',
+			'This diagnostic determines if the Docker daemon suffers from one of the 8GiB filesystem',
+			'layer bugs reported at https://github.com/moby/moby/issues/37581 (affects all platforms) ',
+			'or https://github.com/moby/moby/issues/40444 (Windows containers only)',
 			'',
-			'This bug was fixed in Docker CE 18.09.0, but still exists in some versions of',
-			'Docker CE under Windows 10 and Docker EE under Windows Server.',
+			'#37581 was fixed in Docker CE 18.09.0, but #40444 has not been fixed as-of Docker CE 19.03.12',
 			'',
 			self._parser.format_help()
 		])

--- a/ue4docker/dockerfiles/diagnostics/8gig/windows/Dockerfile
+++ b/ue4docker/dockerfiles/diagnostics/8gig/windows/Dockerfile
@@ -6,19 +6,5 @@ SHELL ["cmd", "/S", "/C"]
 # Add a sentinel label so we can easily identify intermediate images
 LABEL com.adamrehn.ue4-docker.sentinel="1"
 
-# Write an 8GiB file in blocks of 1GiB to avoid allocating too much memory in one hit
-RUN powershell "`
-	$ErrorActionPreference = 'Stop';`
-	$writer = [System.IO.File]::OpenWrite('file');`
-	`
-	$random = new-object Random;`
-	$blockSize = 1073741824;`
-	$bytes = new-object byte[] $blockSize;`
-	for ($i=0; $i -lt 8; $i++)`
-	{`
-		$random.NextBytes($bytes);`
-		$writer.Write($bytes, 0, $blockSize);`
-	}`
-	`
-	$writer.Close();`
-	"
+# Write an 8GiB sparse file
+RUN powershell "fsutil.exe file createnew file 8589934592"


### PR DESCRIPTION
This speeds up the test by using a sparse file on Windows (as suggested at https://github.com/moby/moby/pull/41430#discussion_r486033708) and updates the in-script documentation to highlight that there were actually two different bugs, rather than being a bugfix which was partially ineffective.

I tested that the 8gig repro continues to take effect on a Windows 10 1909 machine with Docker Daemon 19.03.12, and subtracting 1 from the size causes the failure to not reproduce.

Both of the known 8gig issues are around the tarfile data stream, which isn't affected by the sparseness of the file being archived, as the OCI Layer specification forbids sparse files in the tar stream, so the file is treated naively.