### PR TITLE
Removed xml printing from log to prevent log flooding.

### DIFF
--- a/ue4docker/dockerfiles/ue4-source/linux/patch-broken-releases.py
+++ b/ue4docker/dockerfiles/ue4-source/linux/patch-broken-releases.py
@@ -38,4 +38,4 @@ if versionDetails['MajorVersion'] == 4 and versionDetails['MinorVersion'] == 25 
 		)
 		
 		writeFile(gitdepsFile, gitdepsXml)
-		print('PATCHED {}:\n\n{}'.format(gitdepsFile, gitdepsXml), file=sys.stderr)
+		print('PATCHED {}'.format(gitdepsFile), file=sys.stderr)

--- a/ue4docker/dockerfiles/ue4-source/windows/patch-broken-releases.py
+++ b/ue4docker/dockerfiles/ue4-source/windows/patch-broken-releases.py
@@ -38,4 +38,4 @@ if versionDetails['MajorVersion'] == 4 and versionDetails['MinorVersion'] == 25 
 		)
 		
 		writeFile(gitdepsFile, gitdepsXml)
-		print('PATCHED {}:\n\n{}'.format(gitdepsFile, gitdepsXml), file=sys.stderr)
+		print('PATCHED {}'.format(gitdepsFile), file=sys.stderr)


### PR DESCRIPTION
Tested on GitLab CICD. Logs would exceed maximum size by printing an enormous xml file.

Now only the file name is printed.

Log:
```
 ---> 6e3baba0d2dc
Step 17/23 : COPY patch-broken-releases.py C:\patch-broken-releases.py
Error removing intermediate container 3c07de5ffa47: No such container: 3c07de5ffa4753f9d51b9ba39082368303ad0c1971474852e16c4de4fb4dbe11
 ---> 566c37109226
Step 18/23 : RUN python C:\patch-broken-releases.py C:\UnrealEngine && echo. && echo.RUN directive complete. Docker will now commit the filesystem layer to disk. && echo.Note that for large filesystem layers this can take quite some time. && echo.Performing filesystem layer commit... && echo.
 ---> Running in b83d0491d71f
[91mPATCHED C:\UnrealEngine\Engine\Build\Commit.gitdeps.xml:

<?xml version="1.0" encoding="utf-8"?>
<DependencyManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" BaseUrl="http://cdn.unrealengine.com/dependencies">
  <Files>
    <File Name=".tgitconfig" Hash="d3d7bbcf9b2fc8b6e4f2965354a5633c4f175589" />
    <File Name="cpp.hint" Hash="7d1daec3c6218ce9f49f9be0280091b98d7168d7" />
    <File Name="Engine/Binaries/DotNET/AgentInterface.dll" Hash="2a45d6cc11ec86fedec55ff7202470c93491d6df" />
    <File Name="Engine/Binaries/DotNET/CsvTools/CSVCollate.exe" Hash="7833fd434845bf2d95f14195d37902bdc59da1b5" />
    <File Name="Engine/Binaries/DotNET/CsvTools/CSVFilter.exe" Hash="7ad8cb92ce03b75f8a9786d63096654d1fbb5c13" />
    <File Name="Engine/Binaries/DotNET/CsvTools/csvinfo.exe" Hash="622eabedd545545c71ae137fa86f3faa27d3b1af" />
    <File Name="Engine/Binaries/DotNET/CsvTools/CSVSplit.exe" Hash="fee486b775c8100988c88317a074e0fcb19bed13" />
    <File Name="Engine/Binaries/DotNET/CsvTools/CsvStats.dll" Hash="d4b41df1b97209b2e5c890c25f65453765d5f361" />
    <File Name="Engine/Binaries/DotNET/CsvTools/CSVToSVG.exe" Hash="560069559b99fecd5a2becb8b3286010486d822b" />
    <File Name="Engine/Binaries/DotNET/CsvTools/PerfreportTool.exe" Hash="9f4b9465f6e51c5b9a3b7e04d71611f5667574a5" />
    <File Name="Engine/Binaries/DotNET/Ionic.Zip.Reduced.dll" Hash="a991703deda7721e68adfaded64291bbdda85a12" />
    <File Name="Engine/Binaries/DotNET/IOS/DeploymentInterface.dll" Hash="4928199bde8533bcbfa8d1f4a5810cf502e1c0ea" />
    <File Name="Engine/Binaries/DotNET/IOS/DeploymentServer.exe" Hash="a6d184384e85ba0e14643ac37c941ba84086d029" />
    <File Name="Engine/Binaries/DotNET/IOS/DeploymentServerLauncher.exe" Hash="d06a63d1056d837718461081f3bdbb3c1535d216" />
    <File Name="Engine/Binaries/DotNET/IOS/DotNETUtilities.dll" Hash="cc22b1b7f4ab6db3509de4d835bb08c8218481a0" />
    <File Name="Engine/Binaries/DotNET/IOS/IPhonePackager.exe" Hash="1d459627092a5b2f9e911565c9890c5e7ec7e266" />
    <File Name="Engine/Binaries/DotNET/IOS/MobileDeviceInterface.dll" Hash="9980cedbc9265c9a87b70b6eaadc852953afacff" />
    <File Name="Engine/Binaries/DotNET/IOS/openssl.exe" Hash="f4d2d872d8efc2662ff4785fb164f968ec8349c4" />
    <File Name="Engine/Binaries/DotNET/NetworkProfiler.exe" Hash="5ac22e93b6540b4e17e3cee5d41f69869d4ea222" IsExecutable="true" />
    <File Name="Engine/Binaries/DotNET/OneSky.dll" Hash="19bd773d37565a24b3cd18dd79c9c6c26bd26282" />
    <File Name="Engine/Binaries/DotNET/SwarmAgent.exe" Hash="8948511398e9614437ba1804c83ee22bee4c156a" IsExecutable="true" />
    <File Name="Engine/Binaries/DotNET/SwarmCommonUtils.dll" Hash="409ad72c5855ed088afef6d4ee0cd87c2684785b" />
   
... logging forever ...
```