### PR TITLE
pip upgrade needed to solve ModuleNotFoundError: No module named 'set…

### DIFF
--- a/ue4docker/dockerfiles/ue4-full/linux/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-full/linux/Dockerfile
@@ -9,6 +9,7 @@ ARG CONAN_UE4CLI_VERSION
 
 # Install ue4cli and conan-ue4cli
 USER root
+RUN pip3 install -U pip
 RUN pip3 install setuptools wheel
 RUN pip3 install "$UE4CLI_VERSION" "$CONAN_UE4CLI_VERSION"
 USER ue4
@@ -28,6 +29,7 @@ RUN git clone "https://github.com/adamrehn/UE4Capture.git" /home/ue4/UE4Capture
 # Install CMake, ue4cli, conan-ue4cli, and ue4-ci-helpers
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends cmake
+RUN pip3 install -U pip
 RUN pip3 install setuptools wheel
 RUN pip3 install "$UE4CLI_VERSION" "$CONAN_UE4CLI_VERSION" ue4-ci-helpers
 USER ue4


### PR DESCRIPTION
I had this issue while building the pixelstreaming UE4 image with :

`ue4-docker build custom:4.25-pixelstreaming -repo=https://github.com/ImmortalEmperor/UnrealEngine.git -branch=4.25-pixelstreaming --cuda=10.2 --no-engine`


```
Collecting cryptography>=2.0 (from SecretStorage>=3.2; sys_platform == "linux"->keyring>=15.1->twine>=1.11.0->ue4cli>=0.0.45)
  Downloading https://files.pythonhosted.org/packages/60/6d/b32368327f600a12e59fb51a904fc6200dd7e65e953fd6fc6ae6468e3423/cryptography-3.4.5.tar.gz (546kB)
    Complete output from command python setup.py egg_info:

            =============================DEBUG ASSISTANCE==========================
            If you are seeing an error here please try the following to
            successfully install cryptography:

            Upgrade to the latest pip and try again. This will fix errors for most
            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
            =============================DEBUG ASSISTANCE==========================

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-p4y6bmx0/cryptography/setup.py", line 14, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-p4y6bmx0/cryptography/
The command '/bin/sh -c pip3 install "$UE4CLI_VERSION" "$CONAN_UE4CLI_VERSION" ue4-ci-helpers && echo '' && echo 'RUN directive complete. Docker will now commit the filesyste                           m layer to disk.' && echo 'Note that for large filesystem layers this can take quite some time.' && echo 'Performing filesystem layer commit...' && echo ''' returned a non-ze                           ro code: 1
[ue4-docker build] Error: failed to build image "adamrehn/ue4-full:4.25-pixelstreaming-cudagl10.2".
```

I made a quick fix by updating pip in the *-full dockerfile.