### PR TITLE
Disable GitDependencies.exe caching to .git/ue4-gitdeps

### DIFF
--- a/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
@@ -67,8 +67,9 @@ RUN python3 /tmp/patch-broken-releases.py /home/ue4/UnrealEngine $VERBOSE_OUTPUT
 
 # Run post-clone setup steps, ensuring our package lists are up to date since Setup.sh doesn't call `apt-get update`
 WORKDIR /home/ue4/UnrealEngine
+# -no-cache disables GitDependencies.exe saving a copy of all dependencies in .git/ue4-gitdeps (around 9GB)
 RUN sudo apt-get update && \
-	./Setup.sh && \
+	./Setup.sh -no-cache && \
 	sudo rm -rf /var/lib/apt/lists/*
 
 {% if (not disable_all_patches) and (not disable_linker_fixup) %}

--- a/ue4docker/dockerfiles/ue4-source/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-source/windows/Dockerfile
@@ -59,7 +59,8 @@ RUN python C:\patch-broken-releases.py C:\UnrealEngine %VERBOSE_OUTPUT%
 
 # Run post-clone setup steps
 WORKDIR C:\UnrealEngine
-RUN Setup.bat
+# -no-cache disables GitDependencies.exe saving a copy of all dependencies in .git/ue4-gitdeps (around 9GB)
+RUN Setup.bat -no-cache
 
 {% if (not disable_all_patches) and (not disable_example_platform_cleanup) %}
 # Remove the sample `XXX` example platform code, since this breaks builds from 4.24.0 onwards


### PR DESCRIPTION
This commit reduces amount of data written to disk during ue4-source image build by ~9GB.