### PR TITLE
Require semver 2.x.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
 		'packaging>=19.1',
 		'psutil',
 		'requests',
-		'semver>=2.7.9',
+		'semver>=2.7.9,<3.0.0',
 		'setuptools>=38.6.0',
 		'termcolor',
 		'twine>=1.11.0',


### PR DESCRIPTION
If there's no semver python module installed and user does `python setup.py develop --user` in ue4-docker repo in order to work on ue4-docker, then semver 3.x.x is pulled in.

1. Semver [website](https://github.com/python-semver/python-semver) clearly says that semver 3.x.x is not for production use until 3.0.0 is released
2. ue4-docker fails to import semver.py because there is no such file in semver 3.x.x