### PR TITLE
Fix dockerfiles to actually remove unneeded directories on Windows

### DIFF
--- a/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
@@ -9,7 +9,7 @@ FROM ${NAMESPACE}/ue4-source:${TAG}-${PREREQS_TAG} AS builder
 {% endif %}
 
 # Remove the .git directory to disable UBT `git status` calls and speed up the build process
-RUN del /s /q C:\UnrealEngine\.git
+RUN rmdir /s /q C:\UnrealEngine\.git
 
 # Set the changelist number in Build.version to ensure our Build ID is generated correctly
 COPY set-changelist.py C:\set-changelist.py
@@ -30,7 +30,7 @@ ARG BUILD_DDC
 WORKDIR C:\UnrealEngine
 COPY exclude-components.py C:\exclude-components.py
 RUN .\Engine\Build\BatchFiles\RunUAT.bat BuildGraph -target="Make Installed Build Win64" -script=Engine/Build/InstalledEngineBuild.xml -set:HostPlatformOnly=true -set:WithDDC=%BUILD_DDC% {{ buildgraph_args }} && `
-	del /s /q C:\UnrealEngine\LocalBuilds\InstalledDDC 2>NUL
+	rmdir /s /q C:\UnrealEngine\LocalBuilds\InstalledDDC 2>NUL
 
 # Determine if we are removing debug symbols and/or template projects in order to reduce the final container image size
 ARG EXCLUDE_DEBUG

--- a/ue4docker/dockerfiles/ue4-source/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-source/windows/Dockerfile
@@ -65,7 +65,7 @@ RUN Setup.bat -no-cache
 {% if (not disable_all_patches) and (not disable_example_platform_cleanup) %}
 # Remove the sample `XXX` example platform code, since this breaks builds from 4.24.0 onwards
 # (For details of what this is, see: <https://forums.unrealengine.com/unreal-engine/announcements-and-releases/1617783-attention-platform-changes-ahead>)
-RUN del /s /q C:\UnrealEngine\Engine\Platforms\XXX 2>NUL || exit 0
+RUN rmdir /s /q C:\UnrealEngine\Engine\Platforms\XXX 2>NUL || exit 0
 {% endif %}
 
 {% if (not disable_all_patches) and (not disable_ubt_patches) %}


### PR DESCRIPTION
It turns out that `del /s` is **not** deleting directory recursively

---

I noticed that UBT is still spending a lot of time checking for Git changes when building `ue4-minimal`. Inspection of container contents showed that `C:\UnrealEngine\.git` directory was still present in container even though it was supposed to be removed by the time engine is built.

Manual testing inside container showed that `del /s /q C:\UnrealEngine\.git` actually does *not* delete neither directory nor Git files inside it.

This PR switches to `rmdir /s /q` that **does** fully delete directory and its contents recursively.