### PR TITLE
Fix engine build with --exclude ddc failing to remove nonexistent directory

### DIFF
--- a/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
@@ -30,7 +30,7 @@ ARG BUILD_DDC
 WORKDIR C:\UnrealEngine
 COPY exclude-components.py C:\exclude-components.py
 RUN .\Engine\Build\BatchFiles\RunUAT.bat BuildGraph -target="Make Installed Build Win64" -script=Engine/Build/InstalledEngineBuild.xml -set:HostPlatformOnly=true -set:WithDDC=%BUILD_DDC% {{ buildgraph_args }} && `
-	rmdir /s /q C:\UnrealEngine\LocalBuilds\InstalledDDC 2>NUL
+	(if exist C:\UnrealEngine\LocalBuilds\InstalledDDC rmdir /s /q C:\UnrealEngine\LocalBuilds\InstalledDDC)
 
 # Determine if we are removing debug symbols and/or template projects in order to reduce the final container image size
 ARG EXCLUDE_DEBUG


### PR DESCRIPTION
It turns out that rmdir returns exitcode=2 if directory to delete doesn't exist.
So, only delete DDC directory if it actually exists.

Broken by 9cf1375c33098a2787b5f514fd0ff36167a12b96.

----

Is this directory actually worth deleting? There are tons of other intermediate build products inside the image that are still left behind. And this intermediate image is going to be thrown away completely a couple of steps later when ue4-minimal image is produced.