### PR TITLE
Reduce ue4-build-prerequisites Windows image

### DIFF
--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
@@ -10,7 +10,7 @@ call refreshenv
 @rem Forcibly disable the git credential manager
 git config --system credential.helper "" || goto :error
 
-@rem Install the Visual Studio 2017 Build Tools workloads and components we need, excluding components with known issues in containers
+@rem Install the Visual Studio 2017 Build Tools workloads and components we need
 @rem (Note that we use the Visual Studio 2019 installer here because the old installer now breaks, but explicitly install the VS2017 Build Tools)
 curl --progress -L "https://aka.ms/vs/16/release/vs_buildtools.exe" --output %TEMP%\vs_buildtools.exe || goto :error
 %TEMP%\vs_buildtools.exe --quiet --wait --norestart --nocache ^
@@ -19,12 +19,14 @@ curl --progress -L "https://aka.ms/vs/16/release/vs_buildtools.exe" --output %TE
 	--installChannelUri "https://aka.ms/vs/15/release/channel" ^
 	--channelId VisualStudio.15.Release ^
 	--productId Microsoft.VisualStudio.Product.BuildTools ^
-	--add Microsoft.VisualStudio.Workload.VCTools;includeRecommended ^
-	--add Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools;includeRecommended ^
-	--add Microsoft.VisualStudio.Workload.UniversalBuildTools ^
-	--add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^
+	--add Microsoft.VisualStudio.Workload.VCTools ^
 	--add Microsoft.VisualStudio.Workload.MSBuildTools ^
-	--add Microsoft.VisualStudio.Component.NuGet
+	--add Microsoft.VisualStudio.Component.NuGet ^
+	--add Microsoft.VisualStudio.Component.Roslyn.Compiler ^
+	--add Microsoft.VisualStudio.Component.Windows10SDK.17763 ^
+	--add Microsoft.Net.Component.4.5.TargetingPack ^
+	--add Microsoft.Net.Component.4.6.2.SDK ^
+	--add Microsoft.Net.Component.4.6.2.TargetingPack
 python C:\buildtools-exitcode.py %ERRORLEVEL% || goto :error
 
 @rem Copy pdbcopy.exe to the expected location(s)

--- a/ue4docker/infrastructure/BuildConfiguration.py
+++ b/ue4docker/infrastructure/BuildConfiguration.py
@@ -231,7 +231,7 @@ class BuildConfiguration(object):
 		
 		# Store the tag for the base Windows Server Core image
 		self.basetag = self.args.basetag if self.args.basetag is not None else self.hostBasetag
-		self.baseImage = 'mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-' + self.basetag
+		self.baseImage = 'mcr.microsoft.com/windows/servercore:' + self.basetag
 		self.prereqsTag = self.basetag
 		
 		# Verify that any user-specified base tag is valid


### PR DESCRIPTION
This commit:

1. Replaces base image from mcr.microsoft.com/dotnet/framework/sdk to mcr.microsoft.com/windows/servercore
The former is 9GB while the latter is just 5GB.
dotnet/framework/sdk contains lots of things that are not actually needed to build ue4,
the hugest is VS Test Agent + VS Build Tools 2019 that take together 2.2GB

2. Stops installing unneeded VS Build Tools workloads/components and only installs required minimum:
* MSBuild (needed to build MSBuild-based UE4 tools, like UBT)
* NuGet (required to run MSBuild and also [checked in GenerateProjectFiles.bat](https://github.com/EpicGames/UnrealEngine/blob/4.26.1-release/Engine/Build/BatchFiles/GenerateProjectFiles.bat#L31-L54))
* C# compiler (needed to build C# UE4 tools)
* .NET SDK 4.5 + 4.6.2 (same as above)
* Windows 10 SDK (needed to build C++ code)
* VCTools: C++ compiler, VC redist (same as above)

Cumulatively, this commit reduces ue4-build-prerequisites image from 24.5GB down to 10.7GB.
The most important consequence of this change is that it reduces ue4-minimal/ue4-full image sizes by the same delta

----

See https://github.com/adamrehn/ue4-docker/pull/144#issuecomment-810395548 for test matrix of this PR.