### PR TITLE
Mark as EOL Windows releases no longer supported by Microsoft

### DIFF
--- a/ue4docker/infrastructure/WindowsUtils.py
+++ b/ue4docker/infrastructure/WindowsUtils.py
@@ -22,7 +22,7 @@ class WindowsUtils(object):
 	_blacklistedReleases = ['1903', '1909']
 	
 	# The list of Windows Server Core container image releases that are unsupported due to having reached EOL
-	_eolReleases = ['1709']
+	_eolReleases = ['1709', '1803', '1903']
 	
 	@staticmethod
 	def _getVersionRegKey(subkey):


### PR DESCRIPTION
According to [Base image servicing lifecycles](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle), these Windows Server Core releases are already EOL as of today
