### PR TITLE
Only copy exclude-components.py to ue4-minimal when it is actually needed

### DIFF
--- a/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile
@@ -34,11 +34,11 @@ RUN ./Engine/Build/BatchFiles/Linux/Build.sh UE4Editor Linux Development -Clean
 # Create an Installed Build of the Engine
 ARG BUILD_DDC
 WORKDIR /home/ue4/UnrealEngine
-COPY exclude-components.py /tmp/exclude-components.py
 RUN ./Engine/Build/BatchFiles/RunUAT.sh BuildGraph -target="Make Installed Build Linux" -script=Engine/Build/InstalledEngineBuild.xml -set:HostPlatformOnly=true -set:WithDDC=$BUILD_DDC {{ buildgraph_args }} && \
 	rm -R -f /home/ue4/UnrealEngine/LocalBuilds/InstalledDDC
 
 # Determine if we are removing debug symbols and/or template projects in order to reduce the final container image size
+COPY exclude-components.py /tmp/exclude-components.py
 ARG EXCLUDE_DEBUG
 ARG EXCLUDE_TEMPLATES
 RUN python3 /tmp/exclude-components.py /home/ue4/UnrealEngine/LocalBuilds/Engine/Linux $EXCLUDE_DEBUG $EXCLUDE_TEMPLATES

--- a/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
@@ -28,11 +28,11 @@ RUN python C:\patch-build-graph.py C:\UnrealEngine\Engine\Build\InstalledEngineB
 # Create an Installed Build of the Engine
 ARG BUILD_DDC
 WORKDIR C:\UnrealEngine
-COPY exclude-components.py C:\exclude-components.py
 RUN .\Engine\Build\BatchFiles\RunUAT.bat BuildGraph -target="Make Installed Build Win64" -script=Engine/Build/InstalledEngineBuild.xml -set:HostPlatformOnly=true -set:WithDDC=%BUILD_DDC% {{ buildgraph_args }} && `
 	(if exist C:\UnrealEngine\LocalBuilds\InstalledDDC rmdir /s /q C:\UnrealEngine\LocalBuilds\InstalledDDC)
 
 # Determine if we are removing debug symbols and/or template projects in order to reduce the final container image size
+COPY exclude-components.py C:\exclude-components.py
 ARG EXCLUDE_DEBUG
 ARG EXCLUDE_TEMPLATES
 RUN python C:\exclude-components.py C:\UnrealEngine\LocalBuilds\Engine\Windows %EXCLUDE_DEBUG% %EXCLUDE_TEMPLATES%


### PR DESCRIPTION
This change allows to avoid full engine rebuild when making changes to exclude-components.py