### PR TITLE
resolves #146 remove PDB files instead of truncating them

### DIFF
--- a/ue4docker/dockerfiles/ue4-minimal/windows/exclude-components.py
+++ b/ue4docker/dockerfiles/ue4-minimal/windows/exclude-components.py
@@ -17,19 +17,19 @@ rootDir = sys.argv[1]
 version = json.loads(readFile(join(rootDir, 'Engine', 'Build', 'Build.version')))
 
 # Determine if we are excluding debug symbols
-truncateDebug = len(sys.argv) > 2 and sys.argv[2] == '1'
-if truncateDebug == True:
+excludeDebug = len(sys.argv) > 2 and sys.argv[2] == '1'
+if excludeDebug == True:
 	
-	# Truncate all PDB files to save space whilst avoiding the issues that would be caused by the files being missing
-	log('User opted to exclude debug symbols, truncating all PDB files.')
+	# Remove all PDB files to save space
+	log('User opted to exclude debug symbols, removing all PDB files.')
 	log('Scanning for PDB files in directory {}...'.format(rootDir))
 	pdbFiles = glob.glob(join(rootDir, '**', '*.pdb'), recursive=True)
 	for pdbFile in pdbFiles:
-		log('Truncating PDB file {}...'.format(pdbFile))
+		log('Removing PDB file {}...'.format(pdbFile))
 		try:
-			os.truncate(pdbFile, 0)
+			os.remove(pdbFile)
 		except:
-			log('  Warning: failed to truncate PDB file {}.'.format(pdbFile))
+			log('  Warning: failed to remove PDB file {}.'.format(pdbFile))
 
 # Determine if we are excluding the Engine's template projects and samples
 excludeTemplates = len(sys.argv) > 3 and sys.argv[3] == '1'


### PR DESCRIPTION
This commit fixes 'error CS0045: Unexpected error creating debug information file' that occurs when UE4 builds Engine/Intermediate/Build/BuildRules/UE4Rules.dll on Windows

----

Tested using "way to reproduce" from #146 against UE-4.26.1 on Windows 2019 LTSC and 20H2:

1. `ue4-docker build 4.26.1 --no-engine --exclude ddc --exclude templates --exclude debug`
2. `ue4-docker test 4.26.1`

----

Note that I failed to find any info on **why** truncation was needed in the first place. Truncation was initially implemented in f3f5fbb0db8a0cdfc9d46a90e2785ed7b788c862 but neither commit message nor code comments explain what scenario fails in case PDB files are completely removed. I also failed to find relevant issues on GitHub.