### PR TITLE
Enable TSL1.2 when installing Chocolatey

### DIFF
--- a/ue4docker/dockerfiles/diagnostics/network/windows/Dockerfile
+++ b/ue4docker/dockerfiles/diagnostics/network/windows/Dockerfile
@@ -7,4 +7,4 @@ SHELL ["cmd", "/S", "/C"]
 LABEL com.adamrehn.ue4-docker.sentinel="1"
 
 # Attempt to download the Chocolatey installation script
-RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "(New-Object System.Net.WebClient).DownloadFile('https://chocolatey.org/install.ps1', 'install.ps1')"
+RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; (New-Object System.Net.WebClient).DownloadFile('https://chocolatey.org/install.ps1', 'install.ps1')"

--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir C:\GatheredDlls
 
 # Install 7-Zip, curl, and Python using Chocolatey
 # (Note that these need to be separate RUN directives for `choco` to work)
-RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 RUN choco install -y 7zip curl && choco install -y python --version=3.7.5
 
 # Copy the required DirectSound/DirectDraw and OpenGL DLL files from the host system (since these ship with Windows and don't have installers)
@@ -57,7 +57,7 @@ LABEL com.adamrehn.ue4-docker.sentinel="1"
 RUN reg add HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f
 
 # Install Chocolatey
-RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 
 # Install the rest of our build prerequisites and clean up afterwards to minimise image size
 COPY buildtools-exitcode.py copy.py copy-pdbcopy.py install-prerequisites.bat C:\


### PR DESCRIPTION
This commit fixes "Could not create SSL/TLS secure channel" error on
Windows Server LTSC 2016.

In Windows Server LTSC 2016, TLS 1.2 is disabled by default and
chocolatey.org doesn't accept older TLS versions since Feb 2020.

See https://github.com/adamrehn/ue4-docker/issues/151#issuecomment-815072013
and
https://blog.chocolatey.org/2020/01/remove-support-for-old-tls-versions/