### PR TITLE
Fix curl --progress flag

### DIFF
--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/Dockerfile
@@ -27,7 +27,7 @@ RUN C:\copy.py "C:\GatheredDlls\*.dll" C:\Windows\System32\
 RUN python C:\verify-host-dlls.py %HOST_VERSION% C:\GatheredDlls
 
 # Gather the required DirectX runtime files, since Windows Server Core does not include them
-RUN curl --progress -L "https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe" --output %TEMP%\directx_redist.exe
+RUN curl --progress-bar -L "https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe" --output %TEMP%\directx_redist.exe
 RUN start /wait %TEMP%\directx_redist.exe /Q /T:%TEMP% && `
 	expand %TEMP%\APR2007_xinput_x64.cab -F:xinput1_3.dll C:\GatheredDlls\ && `
 	expand %TEMP%\Jun2010_D3DCompiler_43_x64.cab -F:D3DCompiler_43.dll C:\GatheredDlls\ && `
@@ -36,7 +36,7 @@ RUN start /wait %TEMP%\directx_redist.exe /Q /T:%TEMP% && `
 	expand %TEMP%\Jun2010_XAudio_x64.cab -F:XAudio2_7.dll C:\GatheredDlls\
 
 # Gather the Vulkan runtime library
-RUN curl --progress -L "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-runtime-components.zip?u=" --output %TEMP%\vulkan-runtime-components.zip
+RUN curl --progress-bar -L "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-runtime-components.zip?u=" --output %TEMP%\vulkan-runtime-components.zip
 RUN 7z e %TEMP%\vulkan-runtime-components.zip -oC:\GatheredDlls -y "*\x64\vulkan-1.dll"
 
 # Gather pdbcopy.exe (needed for creating an Installed Build of the Engine)

--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
@@ -12,7 +12,7 @@ git config --system credential.helper "" || goto :error
 
 @rem Install the Visual Studio 2017 Build Tools workloads and components we need, excluding components with known issues in containers
 @rem (Note that we use the Visual Studio 2019 installer here because the old installer now breaks, but explicitly install the VS2017 Build Tools)
-curl --progress -L "https://aka.ms/vs/16/release/vs_buildtools.exe" --output %TEMP%\vs_buildtools.exe || goto :error
+curl --progress-bar -L "https://aka.ms/vs/16/release/vs_buildtools.exe" --output %TEMP%\vs_buildtools.exe || goto :error
 %TEMP%\vs_buildtools.exe --quiet --wait --norestart --nocache ^
 	--installPath C:\BuildTools ^
 	--channelUri "https://aka.ms/vs/15/release/channel" ^


### PR DESCRIPTION
This commit fixes "curl: option --progress: is ambiguous" error

curl never had --progress flag. Instead, it has --progress-bar.
--progress worked before due to heuristic logic,
but not it became ambiguous.

See https://github.com/adamrehn/ue4-docker/issues/151#issuecomment-815141996 and https://github.com/moby/moby/pull/40914