### PR TITLE
Force English locale when installing VS Build Tools

### DIFF
--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
@@ -19,6 +19,7 @@ curl --progress-bar -L "https://aka.ms/vs/16/release/vs_buildtools.exe" --output
 	--installChannelUri "https://aka.ms/vs/15/release/channel" ^
 	--channelId VisualStudio.15.Release ^
 	--productId Microsoft.VisualStudio.Product.BuildTools ^
+	--locale en-US ^
 	--add Microsoft.VisualStudio.Workload.VCTools ^
 	--add Microsoft.VisualStudio.Workload.MSBuildTools ^
 	--add Microsoft.VisualStudio.Component.NuGet ^


### PR DESCRIPTION
Before this commit, VS Build Tools installer would pick up system locale from host machine, leading to inconsistent results depending on machine that is used to build ue4-build-prerequisites image

Installer locale affects what language cl.exe and other tools will use to produce error messages.

----

Tested on ltsc2019 + 20H2 against UE-4.26.2