### PR TITLE
Un-hardcode list of Windows versions

### DIFF
--- a/ue4docker/build.py
+++ b/ue4docker/build.py
@@ -138,13 +138,8 @@ def build():
 				logger.error('https://unrealcontainers.com/docs/concepts/windows-containers', False)
 				sys.exit(1)
 
-			# Verify that the user is not attempting to build images with a newer kernel version than the host OS
-			if WindowsUtils.isNewerBaseTag(config.hostBasetag, config.basetag):
-				logger.error('Error: cannot build container images with a newer kernel version than that of the host OS!')
-				sys.exit(1)
-
 			# Check if the user is building a different kernel version to the host OS but is still copying DLLs from System32
-			differentKernels = WindowsUtils.isInsiderPreview() or config.basetag != config.hostBasetag
+			differentKernels = config.basetag != config.hostBasetag
 			if config.pullPrerequisites == False and differentKernels == True and config.dlldir == config.defaultDllDir:
 				logger.error('Error: building images with a different kernel version than the host,', False)
 				logger.error('but a custom DLL directory has not specified via the `-dlldir=DIR` arg.', False)

--- a/ue4docker/diagnostics/base.py
+++ b/ue4docker/diagnostics/base.py
@@ -60,8 +60,7 @@ class DiagnosticBase(object):
 		'''
 		
 		# Determine the appropriate container image base tag for the host system release unless the user specified a base tag
-		buildArgs = []
-		defaultBaseTag = WindowsUtils.getReleaseBaseTag(WindowsUtils.getWindowsRelease())
+		defaultBaseTag = WindowsUtils.getWindowsRelease()
 		baseTag = basetagOverride if basetagOverride is not None else defaultBaseTag
 		buildArgs = ['--build-arg', 'BASETAG={}'.format(baseTag)]
 		


### PR DESCRIPTION
Fully resolves #164.

Partially resolves #138 (support for insider base image is still missing)

This commit:
1. Drops the list of valid Windows versions. Instead, ue4-docker now trusts user input and will fail during image download if user enters something nonexistent
2. Drops 1603->ltsc2016, 1809->ltsc2019 and 2009->20H2 renaming. Instead, ue4-docker directly maps host OS release to Windows Server Core image tag
3. However, ue4-docker now uses advanced logic to determine host OS release. It tries to use DisplayName registry key and fallbacks to ReleaseId if DisplayName doesn't exist. This allows to properly detect 20H2 and 21H1 releases.

On the negative side, some checks are lost:
1. It is no longer possible to check that container version is newer that host OS. Though it should still be rejected by Hyper-V
2. ue4-docker no longer prevents user from using suffix that collides with Windows Server Core image tags

----------------

I'm marking this PR as draft because I haven't actually tested this yet and because I'd like to get some feedback before moving further. @TBBIe, @adamrehn, do you have any comments?