### PR TITLE
Add support for Visual Studio 2019

### DIFF
--- a/ue4docker/build.py
+++ b/ue4docker/build.py
@@ -116,6 +116,7 @@ def build():
 			logger.info('Host OS:                      {}'.format(WindowsUtils.systemString()), False)
 			logger.info('Memory limit:                 {}'.format('No limit' if config.memLimit is None else '{:.2f}GB'.format(config.memLimit)), False)
 			logger.info('Detected max image size:      {:.0f}GB'.format(DockerUtils.maxsize()), False)
+			logger.info('Visual Studio:                {}'.format(config.visualStudio), False)
 			logger.info('Directory to copy DLLs from:  {}\n'.format(config.dlldir), False)
 
 			# Verify that the specified base image tag is not a release that has reached End Of Life (EOL)
@@ -240,7 +241,10 @@ def build():
 			# (This is the only image that does not use any user-supplied tag suffix, since the tag always reflects any customisations)
 			prereqsArgs = ['--build-arg', 'BASEIMAGE=' + config.baseImage]
 			if config.containerPlatform == 'windows':
-				prereqsArgs = prereqsArgs + ['--build-arg', 'HOST_BUILD=' + str(WindowsUtils.getWindowsBuild())]
+				prereqsArgs = prereqsArgs + [
+					'--build-arg', 'HOST_BUILD=' + str(WindowsUtils.getWindowsBuild()),
+					'--build-arg', 'VISUAL_STUDIO_BUILD_NUMBER=' + config.visualStudioBuildNumber,
+				]
 			
 			# Build or pull the UE4 build prerequisites image (don't pull it if we're copying Dockerfiles to an output directory)
 			if config.layoutDir is None and config.pullPrerequisites == True:
@@ -282,7 +286,7 @@ def build():
 			# Build the minimal UE4 CI image, unless requested otherwise by the user
 			buildUe4Minimal = config.noMinimal == False
 			if buildUe4Minimal == True:
-				builder.build('ue4-minimal', mainTags, config.platformArgs + config.exclusionFlags + ue4BuildArgs)
+				builder.build('ue4-minimal', mainTags, config.platformArgs + config.exclusionFlags + ue4BuildArgs + config.uatBuildFlags)
 				builtImages.append('ue4-minimal')
 			else:
 				logger.info('User specified `--no-minimal`, skipping ue4-minimal image build.')

--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/Dockerfile
@@ -61,4 +61,5 @@ RUN powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy 
 
 # Install the rest of our build prerequisites and clean up afterwards to minimise image size
 COPY buildtools-exitcode.py copy.py copy-pdbcopy.py install-prerequisites.bat C:\
-RUN C:\install-prerequisites.bat
+ARG VISUAL_STUDIO_BUILD_NUMBER
+RUN C:\install-prerequisites.bat %VISUAL_STUDIO_BUILD_NUMBER%

--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
@@ -10,24 +10,28 @@ call refreshenv
 @rem Forcibly disable the git credential manager
 git config --system credential.helper "" || goto :error
 
-@rem Install the Visual Studio 2017 Build Tools workloads and components we need
-@rem (Note that we use the Visual Studio 2019 installer here because the old installer now breaks, but explicitly install the VS2017 Build Tools)
+set VISUAL_STUDIO_BUILD_NUMBER=%~1
+
+@rem Install the Visual Studio Build Tools workloads and components we need
+@rem NOTE: We use the Visual Studio 2019 installer even for Visual Studio 2017 here because the old installer now breaks
+@rem NOTE: VS2019 Build Tools doesn't have 4.6.2 .NET SDK and what actually gets installed is 4.8
 curl --progress-bar -L "https://aka.ms/vs/16/release/vs_buildtools.exe" --output %TEMP%\vs_buildtools.exe || goto :error
 %TEMP%\vs_buildtools.exe --quiet --wait --norestart --nocache ^
 	--installPath C:\BuildTools ^
-	--channelUri "https://aka.ms/vs/15/release/channel" ^
-	--installChannelUri "https://aka.ms/vs/15/release/channel" ^
-	--channelId VisualStudio.15.Release ^
+	--channelUri "https://aka.ms/vs/%VISUAL_STUDIO_BUILD_NUMBER%/release/channel" ^
+	--installChannelUri "https://aka.ms/vs/%VISUAL_STUDIO_BUILD_NUMBER%/release/channel" ^
+	--channelId VisualStudio.%VISUAL_STUDIO_BUILD_NUMBER%.Release ^
 	--productId Microsoft.VisualStudio.Product.BuildTools ^
 	--locale en-US ^
 	--add Microsoft.VisualStudio.Workload.VCTools ^
 	--add Microsoft.VisualStudio.Workload.MSBuildTools ^
 	--add Microsoft.VisualStudio.Component.NuGet ^
 	--add Microsoft.VisualStudio.Component.Roslyn.Compiler ^
+	--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 ^
 	--add Microsoft.VisualStudio.Component.Windows10SDK.17763 ^
 	--add Microsoft.Net.Component.4.5.TargetingPack ^
-	--add Microsoft.Net.Component.4.6.2.SDK ^
-	--add Microsoft.Net.Component.4.6.2.TargetingPack
+	--add Microsoft.Net.ComponentGroup.4.6.2.DeveloperTools
+
 python C:\buildtools-exitcode.py %ERRORLEVEL% || goto :error
 
 @rem Copy pdbcopy.exe to the expected location(s)

--- a/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
@@ -27,8 +27,9 @@ RUN python C:\patch-build-graph.py C:\UnrealEngine\Engine\Build\InstalledEngineB
 
 # Create an Installed Build of the Engine
 ARG BUILD_DDC
+ARG USE_VS2019
 WORKDIR C:\UnrealEngine
-RUN .\Engine\Build\BatchFiles\RunUAT.bat BuildGraph -target="Make Installed Build Win64" -script=Engine/Build/InstalledEngineBuild.xml -set:HostPlatformOnly=true -set:WithDDC=%BUILD_DDC% {{ buildgraph_args }} && `
+RUN .\Engine\Build\BatchFiles\RunUAT.bat BuildGraph -target="Make Installed Build Win64" -script=Engine/Build/InstalledEngineBuild.xml -set:HostPlatformOnly=true -set:WithDDC=%BUILD_DDC% -set:VS2019=%USE_VS2019% {{ buildgraph_args }} && `
 	(if exist C:\UnrealEngine\LocalBuilds\InstalledDDC rmdir /s /q C:\UnrealEngine\LocalBuilds\InstalledDDC)
 
 # Determine if we are removing debug symbols and/or template projects in order to reduce the final container image size


### PR DESCRIPTION
resolves #172

----

This is not tested yet, I'm currently running builds.

The only questionable thing in this PR is a change to `ue4-build-prerequisites` tag. It effectively makes all `ue4-build-prerequisites` images currently uploaded to DockerHub unusable. We can avoid that by only appending `-vs<number>` to tag for VS2019, but I'm not sure this is a good approach.