### PR TITLE
Stop relying on ReleaseId/DisplayVersion registry keys

### DIFF
--- a/ue4docker/diagnostics/base.py
+++ b/ue4docker/diagnostics/base.py
@@ -61,8 +61,12 @@ class DiagnosticBase(object):
 		
 		# Determine the appropriate container image base tag for the host system release unless the user specified a base tag
 		buildArgs = []
-		defaultBaseTag = WindowsUtils.getReleaseBaseTag(WindowsUtils.getWindowsRelease())
-		baseTag = basetagOverride if basetagOverride is not None else defaultBaseTag
+		hostBaseTag = WindowsUtils.getHostBaseTag()
+		baseTag = basetagOverride if basetagOverride is not None else hostBaseTag
+
+		if baseTag is None:
+			raise RuntimeError('unable to determine Windows Server Core base image tag from host system. Specify it explicitly using -basetag command-line flag')
+
 		buildArgs = ['--build-arg', 'BASETAG={}'.format(baseTag)]
 		
 		# Use the default isolation mode unless requested otherwise
@@ -72,7 +76,7 @@ class DiagnosticBase(object):
 		
 		# If the user specified process isolation mode and a different base tag to the host system then warn them
 		prefix = self.getPrefix()
-		if isolation == 'process' and baseTag != defaultBaseTag:
+		if isolation == 'process' and baseTag != hostBaseTag:
 			logger.info('[{}] Warning: attempting to use different Windows container/host versions'.format(prefix), False)
 			logger.info('[{}] when running in process isolation mode, this will usually break!'.format(prefix), False)
 		

--- a/ue4docker/diagnostics/diagnostic_20gig.py
+++ b/ue4docker/diagnostics/diagnostic_20gig.py
@@ -14,7 +14,7 @@ class diagnostic20Gig(DiagnosticBase):
 		# Setup our argument parser so we can use its help message output in our description text
 		self._parser = argparse.ArgumentParser(prog='ue4-docker diagnostics 20gig')
 		self._parser.add_argument('--isolation', default=None, choices=['hyperv', 'process'], help="Override the default isolation mode when testing Windows containers")
-		self._parser.add_argument('-basetag', default=None, choices=WindowsUtils.getValidBaseTags(), help="Override the default base image tag when testing Windows containers")
+		self._parser.add_argument('-basetag', default=None, choices=WindowsUtils.getKnownBaseTags(), help="Override the default base image tag when testing Windows containers")
 	
 	def getName(self):
 		'''

--- a/ue4docker/diagnostics/diagnostic_8gig.py
+++ b/ue4docker/diagnostics/diagnostic_8gig.py
@@ -16,7 +16,7 @@ class diagnostic8Gig(DiagnosticBase):
 		self._parser.add_argument('--linux', action='store_true', help="Use Linux containers under Windows hosts (useful when testing Docker Desktop or LCOW support)")
 		self._parser.add_argument('--random', action='store_true', help="Create a file filled with random bytes instead of zeroes under Windows")
 		self._parser.add_argument('--isolation', default=None, choices=['hyperv', 'process'], help="Override the default isolation mode when testing Windows containers")
-		self._parser.add_argument('-basetag', default=None, choices=WindowsUtils.getValidBaseTags(), help="Override the default base image tag when testing Windows containers")
+		self._parser.add_argument('-basetag', default=None, choices=WindowsUtils.getKnownBaseTags(), help="Override the default base image tag when testing Windows containers")
 	
 	def getName(self):
 		'''

--- a/ue4docker/diagnostics/diagnostic_network.py
+++ b/ue4docker/diagnostics/diagnostic_network.py
@@ -13,7 +13,7 @@ class diagnosticNetwork(DiagnosticBase):
 		self._parser = argparse.ArgumentParser(prog='ue4-docker diagnostics network')
 		self._parser.add_argument('--linux', action='store_true', help="Use Linux containers under Windows hosts (useful when testing Docker Desktop or LCOW support)")
 		self._parser.add_argument('--isolation', default=None, choices=['hyperv', 'process'], help="Override the default isolation mode when testing Windows containers")
-		self._parser.add_argument('-basetag', default=None, choices=WindowsUtils.getValidBaseTags(), help="Override the default base image tag when testing Windows containers")
+		self._parser.add_argument('-basetag', default=None, choices=WindowsUtils.getKnownBaseTags(), help="Override the default base image tag when testing Windows containers")
 	
 	def getName(self):
 		'''


### PR DESCRIPTION
Instead, we now use Windows build numbers to identify host system.

This is a preparation step to add support for Windows Server 2022 LTSC,
 whose DisplayVersion (21H2) collides with Windows 10 21H2 and Windows 11 21H2.

This commit also removes EOLed Windows 1903 and 1909 in order to reduce lookup tables that we have to hardcode.