### PR TITLE
Install Windows SDK >= 18362 when using VS2019 to fix compilation of UE-4.27.0

### DIFF
--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
@@ -33,6 +33,29 @@ powershell -Command "Copy-Item -Path \"*\x64\vulkan-1.dll\" -Destination C:\Wind
 
 set VISUAL_STUDIO_BUILD_NUMBER=%~1
 
+@rem Use the latest available Windows SDK. The motivation behind this is:
+@rem 1. Newer SDKs allow developers to use newer APIs. Developers can guard that API usage with runtime version checks if they want to continue to support older Windows releases.
+@rem 2. Unreal Engine slowly moves to newer Windows SDK. 4.27.0 no longer compiles with SDKs older than 18362 and even if it will be fixed in 4.27.x,
+@rem    this is just a question of a time when older SDKs support will be dropped completely
+@rem 3. UE5 doesn't support VS2017 at all, so in the future that argument for continuing to use Windows SDK 17763 from VS2017 era will be weaker and weaker.
+@rem
+@rem We can't use newer SDK for VS2017 that is used to compile older engines because 18362 SDK support was only added in UE-4.23.
+@rem
+@rem See https://github.com/adamrehn/ue4-docker/issues/192
+@rem See https://forums.unrealengine.com/t/ndis_miniport_major_version-is-not-defined-error/135058
+@rem See https://github.com/EpicGames/UnrealEngine/blame/4.23.0-release/Engine/Source/Programs/UnrealBuildTool/Platform/Windows/UEBuildWindows.cs#L1822-L1823
+@rem See https://github.com/EpicGames/UnrealEngine/commit/ecc4872c3269e75a24adc40734cc8bcc9bbed1ca
+@rem See https://udn.unrealengine.com/s/question/0D54z000079HcjJCAS/d3d12h427-error-c4668-winapipartitiongames-is-not-defined-as-a-preprocessor-macro-replacing-with-0-for-ifelif
+@rem
+@rem Keywords for Google:
+@rem error C4668: 'NDIS_MINIPORT_MAJOR_VERSION' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif
+@rem d3d12.h(427): error C4668: 'WINAPI_PARTITION_GAMES' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
+if "%VISUAL_STUDIO_BUILD_NUMBER%" == "15" (
+    set WINDOWS_SDK_VERSION=17763
+) else (
+    set WINDOWS_SDK_VERSION=20348
+)
+
 @rem Install the Visual Studio Build Tools workloads and components we need
 @rem NOTE: We use the Visual Studio 2019 installer even for Visual Studio 2017 here because the old installer now breaks
 @rem NOTE: VS2019 Build Tools doesn't have 4.6.2 .NET SDK and what actually gets installed is 4.8
@@ -49,7 +72,7 @@ curl --progress-bar -L "https://aka.ms/vs/16/release/vs_buildtools.exe" --output
 	--add Microsoft.VisualStudio.Workload.MSBuildTools ^
 	--add Microsoft.VisualStudio.Component.NuGet ^
 	--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 ^
-	--add Microsoft.VisualStudio.Component.Windows10SDK.17763 ^
+	--add Microsoft.VisualStudio.Component.Windows10SDK.%WINDOWS_SDK_VERSION% ^
 	--add Microsoft.Net.Component.4.5.TargetingPack ^
 	--add Microsoft.Net.ComponentGroup.4.6.2.DeveloperTools ^
 	--add Microsoft.NetCore.Component.SDK


### PR DESCRIPTION
resolves #192

----

This is an alternative to #193. See discussion in #192.

P.S. Testing is not finished yet.