### PR TITLE
Fix crash during OpenCVLensDistortion plugin startup

### DIFF
--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/Dockerfile
@@ -10,6 +10,7 @@ SHELL ["cmd", "/S", "/C"]
 # Gather the system DLLs that we need from the full Windows base image
 COPY --from=dlls `
     C:\Windows\System32\avicap32.dll `
+    C:\Windows\System32\avifil32.dll `
     C:\Windows\System32\avrt.dll `
     C:\Windows\System32\d3d10warp.dll `
     C:\Windows\System32\D3DSCache.dll `
@@ -20,6 +21,7 @@ COPY --from=dlls `
     C:\Windows\System32\mfplat.dll `
     C:\Windows\System32\mfplay.dll `
     C:\Windows\System32\mfreadwrite.dll `
+    C:\Windows\System32\msacm32.dll `
     C:\Windows\System32\msdmo.dll `
     C:\Windows\System32\msvfw32.dll `
     C:\Windows\System32\opengl32.dll `


### PR DESCRIPTION
`opencv_world331.dll` depends on `avifil32.dll`/`msacm32.dll` that are missing in ue4-docker images.
This causes OpenCVLensDistortion fail to load and crash, leading to DDC build failure on UE-4.27 unless ue4-docker build is invoked with `--exclude ddc`.

resolves #196

----

Not tested yet.