### PR TITLE
Fix ue4-full build failure on Linux caused by boost-1.67 missing in Conan repo

### DIFF
--- a/ue4docker/dockerfiles/ue4-full/linux/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-full/linux/Dockerfile
@@ -30,9 +30,6 @@ FROM ${NAMESPACE}/ue4-minimal:${TAG}-${PREREQS_TAG}
 ARG UE4CLI_VERSION
 ARG CONAN_UE4CLI_VERSION
 
-# Clone the UE4Capture repository
-RUN git clone "https://github.com/adamrehn/UE4Capture.git" /home/ue4/UE4Capture
-
 # Install CMake, ue4cli, conan-ue4cli, and ue4-ci-helpers
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends cmake
@@ -50,9 +47,6 @@ COPY --from=conan --chown=ue4:ue4 /home/ue4/.conan /home/ue4/.conan
 # Install conan-ue4cli (just generate the profile, since we've already copied the generated packages)
 RUN ue4 setroot /home/ue4/UnrealEngine
 RUN ue4 conan generate --profile-only
-
-# Build the Conan packages for the UE4Capture dependencies
-RUN ue4 conan build MediaIPC-ue4
 
 # Enable PulseAudio support
 USER root


### PR DESCRIPTION
This commit drops [MediaIPC] and [UE4Capture] from ue4-full image.

The motivation behind this change is:

1. UE4Capture only works for 4.19 + 4.20. We just clone into /home/ue4/UE4Capture and not connect to the engine in any way
2. MediaIPC is only needed for UE4Capture, but see previous item.
3. Both of these libs do not look like something useful for generic Unreal Engine usage.
 Users can always install whatever software they need on top of images built by ue4-docker

resolves #201

[MediaIPC]: https://github.com/adamrehn/MediaIPC
[UE4Capture]: https://github.com/adamrehn/UE4Capture