### PR TITLE
Add the ability to clone a specific commit of the Unreal Engine

### DIFF
--- a/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
@@ -42,8 +42,13 @@ RUN --mount=type=secret,id=username,uid=1000,required \
 	mkdir /home/ue4/UnrealEngine && \
 	cd /home/ue4/UnrealEngine && \
 	git init && \
+	{% if git_config %}
+	{% for key, value in git_config.items() %}
+	git config {{ key }} {{ value }} && \
+	{% endfor %}
+	{% endif %}
 	git remote add origin "$GIT_REPO" && \
-	git fetch --progress --depth 1 {{ clone_opts }} origin "$GIT_BRANCH" && \
+	git fetch --progress --depth 1 {{ fetch_opts }} origin "$GIT_BRANCH" && \
 	git checkout FETCH_HEAD
 
 {% else %}
@@ -65,8 +70,13 @@ RUN chmod +x /tmp/git-credential-helper-endpoint.sh
 RUN mkdir /home/ue4/UnrealEngine && \
 	cd /home/ue4/UnrealEngine && \
 	git init && \
+	{% if git_config %}
+	{% for key, value in git_config.items() %}
+	git config {{ key }} {{ value }} && \
+	{% endfor %}
+	{% endif %}
 	git remote add origin "$GIT_REPO" && \
-	git fetch --progress --depth 1 {{ clone_opts }} origin "$GIT_BRANCH" && \
+	git fetch --progress --depth 1 {{ fetch_opts }} origin "$GIT_BRANCH" && \
 	git checkout FETCH_HEAD
 
 {% endif %}

--- a/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
@@ -48,7 +48,7 @@ RUN --mount=type=secret,id=username,uid=1000,required \
 	{% endfor %}
 	{% endif %}
 	git remote add origin "$GIT_REPO" && \
-	git fetch --progress --depth 1 {{ fetch_opts }} origin "$GIT_BRANCH" && \
+	git fetch --progress --depth 1 origin "$GIT_BRANCH" && \
 	git checkout FETCH_HEAD
 
 {% else %}
@@ -76,7 +76,7 @@ RUN mkdir /home/ue4/UnrealEngine && \
 	{% endfor %}
 	{% endif %}
 	git remote add origin "$GIT_REPO" && \
-	git fetch --progress --depth 1 {{ fetch_opts }} origin "$GIT_BRANCH" && \
+	git fetch --progress --depth 1 origin "$GIT_BRANCH" && \
 	git checkout FETCH_HEAD
 
 {% endif %}

--- a/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
@@ -22,7 +22,7 @@ COPY ${SOURCE_LOCATION} /home/ue4/UnrealEngine
 # The git repository that we will clone
 ARG GIT_REPO=""
 
-# The git branch/tag that we will checkout
+# The git branch/tag/commit that we will checkout
 ARG GIT_BRANCH=""
 
 {% if credential_mode == "secrets" %}
@@ -38,7 +38,13 @@ RUN chmod +x /tmp/git-credential-helper-secrets.sh
 ARG CHANGELIST
 RUN --mount=type=secret,id=username,uid=1000,required \
 	--mount=type=secret,id=password,uid=1000,required \
-	CHANGELIST="$CHANGELIST" git clone --progress --depth=1 -b $GIT_BRANCH $GIT_REPO {{ clone_opts }} /home/ue4/UnrealEngine
+	CHANGELIST="$CHANGELIST" \
+	mkdir /home/ue4/UnrealEngine && \
+	cd /home/ue4/UnrealEngine && \
+	git init && \
+	git remote add origin "$GIT_REPO" && \
+	git fetch --progress --depth 1 {{ clone_opts }} origin "$GIT_BRANCH" && \
+	git checkout FETCH_HEAD
 
 {% else %}
 
@@ -56,7 +62,12 @@ ENV GIT_ASKPASS=/tmp/git-credential-helper-endpoint.sh
 RUN chmod +x /tmp/git-credential-helper-endpoint.sh
 
 # Clone the UE4 git repository using the endpoint-supplied credentials
-RUN git clone --progress --depth=1 -b $GIT_BRANCH $GIT_REPO {{ clone_opts }} /home/ue4/UnrealEngine
+RUN mkdir /home/ue4/UnrealEngine && \
+	cd /home/ue4/UnrealEngine && \
+	git init && \
+	git remote add origin "$GIT_REPO" && \
+	git fetch --progress --depth 1 {{ clone_opts }} origin "$GIT_BRANCH" && \
+	git checkout FETCH_HEAD
 
 {% endif %}
 

--- a/ue4docker/dockerfiles/ue4-source/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-source/windows/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir C:\UnrealEngine && \
 	{% endfor %}
 	{% endif %}
 	git remote add origin %GIT_REPO% && \
-	git fetch --progress --depth 1 {{ fetch_opts }} origin %GIT_BRANCH% && \
+	git fetch --progress --depth 1 origin %GIT_BRANCH% && \
 	git checkout FETCH_HEAD
 
 {% endif %}

--- a/ue4docker/dockerfiles/ue4-source/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-source/windows/Dockerfile
@@ -43,8 +43,13 @@ WORKDIR C:\
 RUN mkdir C:\UnrealEngine && \
 	cd C:\UnrealEngine && \
 	git init && \
+	{% if git_config %}
+	{% for key, value in git_config.items() %}
+	git config {{ key }} {{ value }} && \
+	{% endfor %}
+	{% endif %}
 	git remote add origin %GIT_REPO% && \
-	git fetch --progress --depth 1 {{ clone_opts }} origin %GIT_BRANCH% && \
+	git fetch --progress --depth 1 {{ fetch_opts }} origin %GIT_BRANCH% && \
 	git checkout FETCH_HEAD
 
 {% endif %}

--- a/ue4docker/dockerfiles/ue4-source/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-source/windows/Dockerfile
@@ -23,7 +23,7 @@ COPY ${SOURCE_LOCATION} C:\UnrealEngine
 # The git repository that we will clone
 ARG GIT_REPO=""
 
-# The git branch/tag that we will checkout
+# The git branch/tag/commit that we will checkout
 ARG GIT_BRANCH=""
 
 # Retrieve the address for the host that will supply git credentials
@@ -40,7 +40,12 @@ ENV GIT_ASKPASS=C:\git-credential-helper.bat
 
 # Clone the UE4 git repository using the host-supplied credentials
 WORKDIR C:\
-RUN git clone --progress --depth=1 -b %GIT_BRANCH% %GIT_REPO% {{ clone_opts }} C:\UnrealEngine
+RUN mkdir C:\UnrealEngine && \
+	cd C:\UnrealEngine && \
+	git init && \
+	git remote add origin %GIT_REPO% && \
+	git fetch --progress --depth 1 {{ clone_opts }} origin %GIT_BRANCH% && \
+	git checkout FETCH_HEAD
 
 {% endif %}
 


### PR DESCRIPTION
This replaces the `git clone` command in the ue4-source Dockerfiles with an `init`/`fetch`/`checkout` workflow, which makes it possible to [clone specific commits using their commit hash](https://stackoverflow.com/questions/31278902/how-to-shallow-clone-a-specific-commit-with-depth-1/43136160#43136160). This is tremendously useful when building and testing container images for currently unreleased versions of the Unreal Engine (5.0 at the time of writing) where stability of the Engine's build health is not yet guaranteed and it may be necessary to select specific commits in order to ensure a successful build.

The only potential issue with this change is that it alters the semantics of the `clone_opts` template option introduced in 46664f8, since the value of this option will now be passed to `git fetch` rather than `git clone` and the overlap in supported flags between these two commands is not 100%.

@slonopotamus what are your thoughts on this? Will the intended use case(s) for `clone_opts` still be satisfied by the flags supported by `git fetch`? If so, should we rename the template option to `fetch_opts` to reflect this new placement, or leave the current name as-is?