### PR TITLE
Improve ue4-build-prerequisites on Linux

### DIFF
--- a/ue4docker/build.py
+++ b/ue4docker/build.py
@@ -262,18 +262,9 @@ def build():
                 sys.exit(1)
 
         elif config.containerPlatform == "linux":
-
-            # Determine if we are building CUDA-enabled container images
-            capabilities = (
-                "CUDA {} + OpenGL".format(config.cuda)
-                if config.cuda is not None
-                else "OpenGL"
-            )
             logger.info("LINUX CONTAINER SETTINGS", False)
             logger.info(
-                "Building GPU-enabled images compatible with NVIDIA Docker ({} support).\n".format(
-                    capabilities
-                ),
+                "Base OS image: {}\n".format(config.baseImage),
                 False,
             )
 

--- a/ue4docker/infrastructure/BuildConfiguration.py
+++ b/ue4docker/infrastructure/BuildConfiguration.py
@@ -15,13 +15,7 @@ DEFAULT_GIT_REPO = "https://github.com/EpicGames/UnrealEngine.git"
 # The base images for Linux containers
 LINUX_BASE_IMAGES = {
     "opengl": "nvidia/opengl:1.0-glvnd-devel-{ubuntu}",
-    "cudagl": {
-        "9.2": "nvidia/cudagl:9.2-devel-{ubuntu}",
-        "10.0": "nvidia/cudagl:10.0-devel-{ubuntu}",
-        "10.1": "nvidia/cudagl:10.1-devel-{ubuntu}",
-        "10.2": "nvidia/cudagl:10.2-devel-{ubuntu}",
-        "11.4": "nvidia/cudagl:11.4.2-devel-{ubuntu}",
-    },
+    "cudagl": "nvidia/cudagl:{cuda}-devel-{ubuntu}",
 }
 
 # The default ubuntu base to use
@@ -191,7 +185,7 @@ class BuildConfiguration(object):
         )
         parser.add_argument(
             "-basetag",
-            default=None,
+            default=None if platform.system() == "Windows" else DEFAULT_LINUX_VERSION,
             help="Operating system base image tag to use. For Linux this is the version of Ubuntu (default is ubuntu18.04). "
             "For Windows this is the Windows Server Core base image tag (default is the host OS version)",
         )
@@ -519,33 +513,25 @@ class BuildConfiguration(object):
         if self.suffix.startswith("opengl") or self.suffix.startswith("cudagl"):
             raise RuntimeError('tag suffix cannot begin with "opengl" or "cudagl".')
 
-        self.args.basetag = (
-            self.args.basetag
-            if self.args.basetag is not None
-            else DEFAULT_LINUX_VERSION
-        )
-
         # Determine if we are building CUDA-enabled container images
         self.cuda = None
         if self.args.cuda is not None:
 
             # Verify that the specified CUDA version is valid
             self.cuda = self.args.cuda if self.args.cuda != "" else DEFAULT_CUDA_VERSION
-            if self.cuda not in LINUX_BASE_IMAGES["cudagl"]:
-                raise RuntimeError(
-                    'unsupported CUDA version "{}", supported versions are: {}'.format(
-                        self.cuda, ", ".join([v for v in LINUX_BASE_IMAGES["cudagl"]])
-                    )
-                )
-
             # Use the appropriate base image for the specified CUDA version
-            self.baseImage = LINUX_BASE_IMAGES["cudagl"][self.cuda]
-            self.prereqsTag = "cudagl{}".format(self.cuda)
+            self.baseImage = LINUX_BASE_IMAGES["cudagl"]
+            self.prereqsTag = "cudagl{cuda}-{ubuntu}"
         else:
             self.baseImage = LINUX_BASE_IMAGES["opengl"]
-            self.prereqsTag = "opengl"
+            self.prereqsTag = "opengl-{ubuntu}"
 
-        self.baseImage = self.baseImage.format(ubuntu=self.args.basetag)
+        self.baseImage = self.baseImage.format(
+            cuda=self.args.cuda, ubuntu=self.args.basetag
+        )
+        self.prereqsTag = self.prereqsTag.format(
+            cuda=self.args.cuda, ubuntu=self.args.basetag
+        )
 
     def _processPackageVersion(self, package, version):
 


### PR DESCRIPTION
This is a follow-up to adamrehn/ue4-docker#221

This commit:
1. Removes hardcoded list of CUDA images. Now user can specify whatever version they want, and we do not need to maintain this list
2. Adds base OS name to ue4-build-prerequisites tag for clarity
3. Prints base image tag in `ue4 build` header output

----

@russkel I've somewhat extended your changes from #221, possibly you want to comment on this.