### PR TITLE
RFC: Use BuildKit for all images

### DIFF
--- a/ue4docker/infrastructure/ImageBuilder.py
+++ b/ue4docker/infrastructure/ImageBuilder.py
@@ -71,7 +71,7 @@ class ImageBuilder(object):
             # Determine whether we are building using `docker buildx` with build secrets
             imageTags = self._formatTags(name, tags)
             command = DockerUtils.build(imageTags, self.context(name), args)
-            env = None
+
             if self.platform == "linux" and secrets is not None and len(secrets) > 0:
 
                 # Create temporary files to store the contents of each of our secrets
@@ -85,10 +85,16 @@ class ImageBuilder(object):
                 command = DockerUtils.buildx(
                     imageTags, self.context(name), args, secretFlags
                 )
-                env = {"DOCKER_BUILDKIT": "1"}
 
             # Build the image if it doesn't already exist
-            self._processImage(imageTags[0], name, command, "build", "built", env=env)
+            self._processImage(
+                imageTags[0],
+                name,
+                command,
+                "build",
+                "built",
+                env={"DOCKER_BUILDKIT": "1"},
+            )
 
     def context(self, name):
         """


### PR DESCRIPTION
BuildKit offers much shorter build times

----

This is a somewhat controversial change. On one hand, BuildKit severely improves build times. On the other hand, there *are* reasons why BuildKit is still not enabled by default in Docker.

Some numbers:

Linux
HDD
Ryzen 3700X
ue4-minimal only (ue4-source is already pre-built)
4.20.3
Flags: `--exclude debug --exclude ddc --no-engine --no-full`

`DOCKER_BUILDKIT=1` 1h 6m
`DOCKER_BUILDKIT=0` 1h 27m
