### PR TITLE
Implement --target to replace the old --no-* options.

### DIFF
--- a/ue4docker/build.py
+++ b/ue4docker/build.py
@@ -105,11 +105,12 @@ def build():
             config.combine,
         )
 
-        # Resolve our main set of tags for the generated images
-        mainTags = [
-            "{}{}-{}".format(config.release, config.suffix, config.prereqsTag),
-            config.release + config.suffix,
-        ]
+        # Resolve our main set of tags for the generated images; this is used only for Source and downstream
+        if config.buildTargetSource:
+            mainTags = [
+                "{}{}-{}".format(config.release, config.suffix, config.prereqsTag),
+                config.release + config.suffix,
+            ]
 
         # Print the command-line invocation that triggered this build, masking any supplied passwords
         args = [
@@ -128,10 +129,11 @@ def build():
         )
         if config.custom == True:
             logger.info("Custom name:   " + config.release, False)
-        else:
+        elif config.release is not None:
             logger.info("Release:       " + config.release, False)
-        logger.info("Repository:    " + config.repository, False)
-        logger.info("Branch/tag:    " + config.branch + "\n", False)
+        if config.repository is not None:
+            logger.info("Repository:    " + config.repository, False)
+            logger.info("Branch/tag:    " + config.branch + "\n", False)
 
         # Determine if we are using a custom version for ue4cli or conan-ue4cli
         if config.ue4cliVersion is not None or config.conanUe4cliVersion is not None:
@@ -241,7 +243,7 @@ def build():
 
             # Ensure the Docker daemon is configured correctly
             requiredLimit = WindowsUtils.requiredSizeLimit()
-            if DockerUtils.maxsize() < requiredLimit:
+            if DockerUtils.maxsize() < requiredLimit and config.buildTargetSource:
                 logger.error("SETUP REQUIRED:")
                 logger.error(
                     "The max image size for Windows containers must be set to at least {}GB.".format(
@@ -314,7 +316,10 @@ def build():
             username = ""
             password = ""
 
-        elif builder.willBuild("ue4-source", mainTags) == False:
+        elif (
+            not config.buildTargetSource
+            or builder.willBuild("ue4-source", mainTags) == False
+        ):
 
             # Don't bother prompting the user for any credentials if we're not building the ue4-source image
             logger.info(
@@ -338,11 +343,8 @@ def build():
         if config.args.monitor == True:
             resourceMonitor.start()
 
-        # Start the HTTP credential endpoint as a child process and wait for it to start
+        # Prep for endpoint cleanup, if necessary
         endpoint = None
-        if config.opts.get("credential_mode", "endpoint") == "endpoint":
-            endpoint = CredentialEndpoint(username, password)
-            endpoint.start()
 
         try:
 
@@ -363,58 +365,71 @@ def build():
                 "NAMESPACE={}".format(GlobalConfiguration.getTagNamespace()),
             ]
 
-            # Compute the build options for the UE4 build prerequisites image
-            # (This is the only image that does not use any user-supplied tag suffix, since the tag always reflects any customisations)
-            prereqsArgs = ["--build-arg", "BASEIMAGE=" + config.baseImage]
-            if config.containerPlatform == "windows":
-                prereqsArgs = prereqsArgs + [
-                    "--build-arg",
-                    "DLLSRCIMAGE=" + config.dllSrcImage,
-                    "--build-arg",
-                    "VISUAL_STUDIO_BUILD_NUMBER=" + config.visualStudioBuildNumber,
-                ]
-
             # Build the UE4 build prerequisites image
-            builder.build(
-                "ue4-build-prerequisites",
-                [config.prereqsTag],
-                commonArgs + config.platformArgs + prereqsArgs,
-            )
-            builtImages.append("ue4-build-prerequisites")
+            if config.buildTargetPrerequisites:
+                # Compute the build options for the UE4 build prerequisites image
+                # (This is the only image that does not use any user-supplied tag suffix, since the tag always reflects any customisations)
+                prereqsArgs = ["--build-arg", "BASEIMAGE=" + config.baseImage]
+                if config.containerPlatform == "windows":
+                    prereqsArgs = prereqsArgs + [
+                        "--build-arg",
+                        "DLLSRCIMAGE=" + config.dllSrcImage,
+                        "--build-arg",
+                        "VISUAL_STUDIO_BUILD_NUMBER=" + config.visualStudioBuildNumber,
+                    ]
 
-            # If we're using build secrets then pass the Git username and password to the UE4 source image as secrets
-            secrets = {}
-            if config.opts.get("credential_mode", "endpoint") == "secrets":
-                secrets = {"username": username, "password": password}
+                builder.build(
+                    "ue4-build-prerequisites",
+                    [config.prereqsTag],
+                    commonArgs + config.platformArgs + prereqsArgs,
+                )
+                builtImages.append("ue4-build-prerequisites")
+
+                prereqConsumerArgs = [
+                    "--build-arg",
+                    "PREREQS_TAG={}".format(config.prereqsTag),
+                ]
+            else:
+                logger.info("Skipping ue4-build-prerequisities image build.")
 
             # Build the UE4 source image
-            prereqConsumerArgs = [
-                "--build-arg",
-                "PREREQS_TAG={}".format(config.prereqsTag),
-            ]
-            credentialArgs = [] if len(secrets) > 0 else endpoint.args()
-            ue4SourceArgs = prereqConsumerArgs + [
-                "--build-arg",
-                "GIT_REPO={}".format(config.repository),
-                "--build-arg",
-                "GIT_BRANCH={}".format(config.branch),
-                "--build-arg",
-                "VERBOSE_OUTPUT={}".format("1" if config.verbose == True else "0"),
-            ]
-            builder.build(
-                "ue4-source",
-                mainTags,
-                commonArgs + config.platformArgs + ue4SourceArgs + credentialArgs,
-                secrets,
-            )
-            builtImages.append("ue4-source")
+            if config.buildTargetSource:
+                # Start the HTTP credential endpoint as a child process and wait for it to start
+                if config.opts.get("credential_mode", "endpoint") == "endpoint":
+                    endpoint = CredentialEndpoint(username, password)
+                    endpoint.start()
+
+                # If we're using build secrets then pass the Git username and password to the UE4 source image as secrets
+                secrets = {}
+                if config.opts.get("credential_mode", "endpoint") == "secrets":
+                    secrets = {"username": username, "password": password}
+                credentialArgs = [] if len(secrets) > 0 else endpoint.args()
+
+                ue4SourceArgs = prereqConsumerArgs + [
+                    "--build-arg",
+                    "GIT_REPO={}".format(config.repository),
+                    "--build-arg",
+                    "GIT_BRANCH={}".format(config.branch),
+                    "--build-arg",
+                    "VERBOSE_OUTPUT={}".format("1" if config.verbose == True else "0"),
+                ]
+                builder.build(
+                    "ue4-source",
+                    mainTags,
+                    commonArgs + config.platformArgs + ue4SourceArgs + credentialArgs,
+                    secrets,
+                )
+                builtImages.append("ue4-source")
+            else:
+                logger.info("Skipping ue4-source image build.")
 
             # Build the UE4 Engine source build image, unless requested otherwise by the user
-            ue4BuildArgs = prereqConsumerArgs + [
-                "--build-arg",
-                "TAG={}".format(mainTags[1]),
-            ]
-            if config.noEngine == False:
+            if config.buildTargetEngine:
+                ue4BuildArgs = prereqConsumerArgs + [
+                    "--build-arg",
+                    "TAG={}".format(mainTags[1]),
+                ]
+
                 builder.build(
                     "ue4-engine",
                     mainTags,
@@ -422,18 +437,16 @@ def build():
                 )
                 builtImages.append("ue4-engine")
             else:
-                logger.info(
-                    "User specified `--no-engine`, skipping ue4-engine image build."
-                )
+                logger.info("Skipping ue4-engine image build.")
 
             # Build the minimal UE4 CI image, unless requested otherwise by the user
-            minimalArgs = (
-                ["--build-arg", "CHANGELIST={}".format(config.changelist)]
-                if config.changelist is not None
-                else []
-            )
-            buildUe4Minimal = config.noMinimal == False
-            if buildUe4Minimal == True:
+            if config.buildTargetMinimal == True:
+                minimalArgs = (
+                    ["--build-arg", "CHANGELIST={}".format(config.changelist)]
+                    if config.changelist is not None
+                    else []
+                )
+
                 builder.build(
                     "ue4-minimal",
                     mainTags,
@@ -441,13 +454,10 @@ def build():
                 )
                 builtImages.append("ue4-minimal")
             else:
-                logger.info(
-                    "User specified `--no-minimal`, skipping ue4-minimal image build."
-                )
+                logger.info("Skipping ue4-minimal image build.")
 
             # Build the full UE4 CI image, unless requested otherwise by the user
-            buildUe4Full = buildUe4Minimal == True and config.noFull == False
-            if buildUe4Full == True:
+            if config.buildTargetFull:
 
                 # If custom version strings were specified for ue4cli and/or conan-ue4cli, use them
                 infrastructureFlags = []
@@ -477,9 +487,7 @@ def build():
                 )
                 builtImages.append("ue4-full")
             else:
-                logger.info(
-                    "Not building ue4-minimal or user specified `--no-full`, skipping ue4-full image build."
-                )
+                logger.info("Skipping ue4-full image build.")
 
             # If we are generating Dockerfiles then include information about the options used to generate them
             if config.layoutDir is not None:

--- a/ue4docker/build.py
+++ b/ue4docker/build.py
@@ -423,8 +423,7 @@ def build():
             else:
                 logger.info("Skipping ue4-source image build.")
 
-            # Build the UE4 Engine source build image, unless requested otherwise by the user
-            if config.buildTargetEngine:
+            if config.buildTargetEngine or config.buildTargetMinimal:
                 ue4BuildArgs = prereqConsumerArgs + [
                     "--build-arg",
                     "TAG={}".format(mainTags[1]),

--- a/ue4docker/build.py
+++ b/ue4docker/build.py
@@ -429,6 +429,8 @@ def build():
                     "TAG={}".format(mainTags[1]),
                 ]
 
+            # Build the UE4 Engine source build image, unless requested otherwise by the user
+            if config.buildTargetEngine:
                 builder.build(
                     "ue4-engine",
                     mainTags,

--- a/ue4docker/main.py
+++ b/ue4docker/main.py
@@ -66,7 +66,7 @@ def main():
     COMMANDS = {
         "build": {
             "function": build,
-            "description": "Builds container images for a specific version of UE4",
+            "description": "Builds container images for UE4",
         },
         "clean": {"function": clean, "description": "Cleans built container images"},
         "diagnostics": {


### PR DESCRIPTION
Resolves #227.

This is undertested, I'm afraid; I don't have access to all platforms, nor do I have things set up to even build the `source` image. It is, however, perfectly happy to spit out layouts for all the images, and as I haven't touched any of the actual image generation code, it *should* work. But please test it! I'm assuming you have a functional framework for this.

I took some liberty in moving things into image-specific conditionals, mostly with the goal of making `--target=build-prerequisites` work. Most notably, main tag naming, credential server startup, and a considerable amount of parameter validation are now hidden under `buildTargetSource` checks. Unfortunately this makes the diff look a lot uglier than it should.

Let me know if you'd like changes!