### PR TITLE
Move config.buildTarget* into a dict.

### DIFF
--- a/ue4docker/build.py
+++ b/ue4docker/build.py
@@ -106,7 +106,7 @@ def build():
         )
 
         # Resolve our main set of tags for the generated images; this is used only for Source and downstream
-        if config.buildTargetSource:
+        if config.buildTargets["source"]:
             mainTags = [
                 "{}{}-{}".format(config.release, config.suffix, config.prereqsTag),
                 config.release + config.suffix,
@@ -243,7 +243,7 @@ def build():
 
             # Ensure the Docker daemon is configured correctly
             requiredLimit = WindowsUtils.requiredSizeLimit()
-            if DockerUtils.maxsize() < requiredLimit and config.buildTargetSource:
+            if DockerUtils.maxsize() < requiredLimit and config.buildTargets["source"]:
                 logger.error("SETUP REQUIRED:")
                 logger.error(
                     "The max image size for Windows containers must be set to at least {}GB.".format(
@@ -308,7 +308,7 @@ def build():
             password = ""
 
         elif (
-            not config.buildTargetSource
+            not config.buildTargets["source"]
             or builder.willBuild("ue4-source", mainTags) == False
         ):
 
@@ -357,7 +357,7 @@ def build():
             ]
 
             # Build the UE4 build prerequisites image
-            if config.buildTargetPrerequisites:
+            if config.buildTargets["build-prerequisites"]:
                 # Compute the build options for the UE4 build prerequisites image
                 # (This is the only image that does not use any user-supplied tag suffix, since the tag always reflects any customisations)
                 prereqsArgs = ["--build-arg", "BASEIMAGE=" + config.baseImage]
@@ -384,7 +384,7 @@ def build():
                 logger.info("Skipping ue4-build-prerequisities image build.")
 
             # Build the UE4 source image
-            if config.buildTargetSource:
+            if config.buildTargets["source"]:
                 # Start the HTTP credential endpoint as a child process and wait for it to start
                 if config.opts.get("credential_mode", "endpoint") == "endpoint":
                     endpoint = CredentialEndpoint(username, password)
@@ -414,14 +414,14 @@ def build():
             else:
                 logger.info("Skipping ue4-source image build.")
 
-            if config.buildTargetEngine or config.buildTargetMinimal:
+            if config.buildTargets["engine"] or config.buildTargets["minimal"]:
                 ue4BuildArgs = prereqConsumerArgs + [
                     "--build-arg",
                     "TAG={}".format(mainTags[1]),
                 ]
 
             # Build the UE4 Engine source build image, unless requested otherwise by the user
-            if config.buildTargetEngine:
+            if config.buildTargets["engine"]:
                 builder.build(
                     "ue4-engine",
                     mainTags,
@@ -432,7 +432,7 @@ def build():
                 logger.info("Skipping ue4-engine image build.")
 
             # Build the minimal UE4 CI image, unless requested otherwise by the user
-            if config.buildTargetMinimal == True:
+            if config.buildTargets["minimal"]:
                 minimalArgs = (
                     ["--build-arg", "CHANGELIST={}".format(config.changelist)]
                     if config.changelist is not None
@@ -449,7 +449,7 @@ def build():
                 logger.info("Skipping ue4-minimal image build.")
 
             # Build the full UE4 CI image, unless requested otherwise by the user
-            if config.buildTargetFull:
+            if config.buildTargets["full"]:
 
                 # If custom version strings were specified for ue4cli and/or conan-ue4cli, use them
                 infrastructureFlags = []

--- a/ue4docker/infrastructure/BuildConfiguration.py
+++ b/ue4docker/infrastructure/BuildConfiguration.py
@@ -324,32 +324,36 @@ class BuildConfiguration(object):
         # build-prereq -> source -> engine
         # build-prereq -> source -> minimal -> full
 
-        self.buildTargetPrerequisites = False
-        self.buildTargetSource = False
-        self.buildTargetEngine = False
-        self.buildTargetMinimal = False
-        self.buildTargetFull = False
+        # We initialize these with all the options, with the intent that you should be accessing them directly and not checking for existence
+        # This is to avoid typos giving false-negatives; KeyError is reliable and tells you what you did wrong
+        self.buildTargets = {
+            "build-prerequisites": False,
+            "source": False,
+            "engine": False,
+            "minimal": False,
+            "full": False,
+        }
 
         if "full" in self.args.target or "all" in self.args.target:
-            self.buildTargetFull = True
+            self.buildTargets["full"] = True
             self.args.target += ["minimal"]
 
         if "minimal" in self.args.target or "all" in self.args.target:
-            self.buildTargetMinimal = True
+            self.buildTargets["minimal"] = True
             self.args.target += ["source"]
 
         if "engine" in self.args.target or "all" in self.args.target:
-            self.buildTargetEngine = True
+            self.buildTargets["engine"] = True
             self.args.target += ["source"]
 
         if "source" in self.args.target or "all" in self.args.target:
-            self.buildTargetSource = True
+            self.buildTargets["source"] = True
             self.args.target += ["build-prerequisites"]
 
         if "build-prerequisites" in self.args.target or "all" in self.args.target:
-            self.buildTargetPrerequisites = True
+            self.buildTargets["build-prerequisites"] = True
 
-        if not self.buildTargetPrerequisites:
+        if not self.buildTargets["build-prerequisites"]:
             raise RuntimeError(
                 "we're not building anything; this shouldn't even be possible, but is definitely not useful"
             )
@@ -366,7 +370,7 @@ class BuildConfiguration(object):
             self.args.release = self.args.ue_version
 
         # We care about the version number only if we're building source
-        if self.buildTargetSource:
+        if self.buildTargets["source"]:
             if self.args.release is None:
                 raise RuntimeError("missing `--ue-version` when building source")
 
@@ -483,7 +487,7 @@ class BuildConfiguration(object):
             )
 
         # We care about source_mode and credential_mode only if we're building source
-        if self.buildTargetSource:
+        if self.buildTargets["source"]:
             # Verify that the value for `source_mode` is valid if specified
             validSourceModes = ["git", "copy"]
             if self.opts.get("source_mode", "git") not in validSourceModes:


### PR DESCRIPTION
This ended up being desirable for a few other things, and I admit I was kind of chafing at having a lot of uniquely named member variables.