### PR TITLE
Avoid copying DLL files that already exist under Windows

### DIFF
--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/Dockerfile
@@ -4,8 +4,13 @@ ARG DLLSRCIMAGE
 
 FROM ${DLLSRCIMAGE} as dlls
 
-FROM ${BASEIMAGE} as prerequisites
+FROM ${BASEIMAGE} as deduplication
 SHELL ["cmd", "/S", "/C"]
+
+{% if not disable_labels %}
+# Add a sentinel label so we can easily identify all derived images, including intermediate images
+LABEL com.adamrehn.ue4-docker.sentinel="1"
+{% endif %}
 
 # Gather the system DLLs that we need from the full Windows base image
 COPY --from=dlls `
@@ -29,7 +34,16 @@ COPY --from=dlls `
     C:\Windows\System32\opengl32.dll `
     C:\Windows\System32\ResampleDMO.dll `
     C:\Windows\System32\ResourcePolicyClient.dll `
-    C:\Windows\System32\
+    C:\GatheredDLLs\
+
+# Remove any DLL files that already exist in the target base image, to avoid permission errors when attempting to overwrite existing files with a COPY directive
+COPY remove-duplicate-dlls.ps1 C:\remove-duplicate-dlls.ps1
+RUN powershell -ExecutionPolicy Bypass -File C:\remove-duplicate-dlls.ps1
+
+# Copy the DLL files into a clean image
+FROM ${BASEIMAGE} as prerequisites
+SHELL ["cmd", "/S", "/C"]
+COPY --from=deduplication C:\GatheredDlls\ C:\Windows\System32\
 
 {% if not disable_labels %}
 # Add a sentinel label so we can easily identify all derived images, including intermediate images

--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/remove-duplicate-dlls.ps1
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/remove-duplicate-dlls.ps1
@@ -1,0 +1,11 @@
+$dlls = (Get-ChildItem "C:\GatheredDLLs\*.dll")
+foreach ($dll in $dlls)
+{
+	$filename = $dll.Name
+	$existing = (Get-ChildItem "C:\Windows\System32\${filename}" -ErrorAction SilentlyContinue)
+	if ($existing)
+	{
+		[Console]::Error.WriteLine("${filename} already exists in System32 in the target base image, excluding it from the list of DLL files to copy.")
+		Remove-Item $dll
+	}
+}


### PR DESCRIPTION
Fixes #241.

The initial fix I devised for this problem was to simply copy the DLL files into an intermediate directory and then use `xcopy /y` to copy them into System32, happily overwriting any existing files that the `COPY` directive refused to touch. This was the simplest and least intrusive implementation I could think of, but unfortunately it introduced an additional filesystem layer and increased the size of the `ue4-build-prerequisites` image by the aggregate filesizes of all of the DLL files. Given that the Windows container images are already massive and every megabyte counts, I decided that it was worth the effort of implementing a better solution that does not impact the final image size.

This is the higher-effort fix, whereby DLL files are copied into an extra build stage and duplicates are programmatically identified and removed prior to being copied into the final image. After writing a version of the deduplication script in Python I then remembered that the intermediate build stage lacks the interpreter, and rather than bloating the Dockerfile with additional directives to install Chocolatey and Python, I rewrote the deduplication script in PowerShell. I'm pretty happy with the result, but I'd appreciate feedback from @slonopotamus and/or @TBBle before merging this into master, in case either of you can think of a more elegant solution to this problem.

Alternative solutions that I considered included the introduction of `ARG` directives or Jinja template values to allow us to modify the list of DLL files depending on the selected base image tag, but that approach felt brittle and would potentially require ongoing maintenance if new Windows releases make further additions to the set of DLLs included in the Server Core base image. By contrast, the solution implemented in this PR addresses the problem in a generic way and does not introduce any additional maintenance burden.