### PR TITLE
fix: ensure copied source has correct ownership

### DIFF
--- a/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
@@ -15,7 +15,7 @@ ARG VERBOSE_OUTPUT=0
 
 # Copy the Unreal Engine source code from the host system
 ARG SOURCE_LOCATION
-COPY ${SOURCE_LOCATION} /home/ue4/UnrealEngine
+COPY --chown=ue4:ue4 ${SOURCE_LOCATION} /home/ue4/UnrealEngine
 
 {% else %}
 


### PR DESCRIPTION
When using `-layout` and `--opt source_mode=copy` followed by `docker build` from inside a docker container (docker-in-docker) where the executing user is `root`, the copied source ends up being owned by `root` and the build fails during the `Setup.sh` phase due to permissions issues. This patch fixes the issue by ensuring the copied source is owned by the `ue4` user.

Specifically, the error is the following:

```
chmod: changing permissions of 'bin/mcs': Operation not permitted
chmod: changing permissions of 'bin/xbuild': Operation not permitted
Fixing inconsistent case in filenames.
Setting up Mono
Checking dependencies...
Failed to write file '/home/ue4/UnrealEngine/.ue4dependencies.tmp': Access to the path "/home/ue4/UnrealEngine/.ue4dependencies.tmp" is denied.
Result: 1
```