### PR TITLE
fix: don't try to delete .git if it's not present

### DIFF
--- a/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
@@ -14,7 +14,7 @@ COPY set-changelist.py C:\set-changelist.py
 RUN python C:\set-changelist.py C:\UnrealEngine\Engine\Build\Build.version %CHANGELIST%
 
 # Remove the .git directory to disable UBT `git status` calls and speed up the build process
-RUN rmdir /s /q C:\UnrealEngine\.git
+RUN if exist C:\UnrealEngine\.git rmdir /s /q C:\UnrealEngine\.git
 
 {% if (not disable_all_patches) and (not disable_buildgraph_patches) %}
 # Patch out problematic entries in InstalledEngineFilters.xml introduced in UE4.20.0


### PR DESCRIPTION
When using `--opt source_mode=copy` with a custom `.dockerignore` that excludes the `.git` directory from the docker build context, the `rmdir .git` command fails with `The system cannot find the file specified.` since docker does not have that directory in context. This patch avoids this scenario with a simple existence check.