### PR TITLE
Add support for Visual Studio 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,11 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-20.04 ]
+        include:
+        - { os: windows-2019, visual-studio: 2017 }
+        - { os: windows-2019, visual-studio: 2019 }
+        - { os: windows-2019, visual-studio: 2022 }
+        - { os: ubuntu-20.04 }
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -40,4 +44,4 @@ jobs:
     - name: Install
       run: pip install . --user
     - name: Test
-      run: ue4-docker build --target=build-prerequisites
+      run: ue4-docker build --target=build-prerequisites --visual-studio ${{ matrix.visual-studio || '2017' }}

--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
@@ -57,10 +57,10 @@ if "%VISUAL_STUDIO_BUILD_NUMBER%" == "15" (
 )
 
 @rem Install the Visual Studio Build Tools workloads and components we need
-@rem NOTE: We use the Visual Studio 2019 installer even for Visual Studio 2017 here because the old installer now breaks
+@rem NOTE: We use the Visual Studio 2022 installer even for Visual Studio 2019 and 2017 here because the old (2017) installer now breaks
 @rem NOTE: VS2019 Build Tools doesn't have 4.6.2 .NET SDK and what actually gets installed is 4.8
 @rem NOTE: Microsoft.NetCore.Component.SDK only exists for VS2019. And it is actually *needed* only for UE5
-curl --progress-bar -L "https://aka.ms/vs/16/release/vs_buildtools.exe" --output %TEMP%\vs_buildtools.exe || goto :error
+curl --progress-bar -L "https://aka.ms/vs/17/release/vs_buildtools.exe" --output %TEMP%\vs_buildtools.exe || goto :error
 %TEMP%\vs_buildtools.exe --quiet --wait --norestart --nocache ^
 	--installPath C:\BuildTools ^
 	--channelUri "https://aka.ms/vs/%VISUAL_STUDIO_BUILD_NUMBER%/release/channel" ^

--- a/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
+++ b/ue4docker/dockerfiles/ue4-build-prerequisites/windows/install-prerequisites.bat
@@ -57,7 +57,6 @@ if "%VISUAL_STUDIO_BUILD_NUMBER%" == "15" (
 
 @rem Install the Visual Studio Build Tools workloads and components we need
 @rem NOTE: We use the Visual Studio 2022 installer even for Visual Studio 2019 and 2017 here because the old (2017) installer now breaks
-@rem NOTE: VS2019 Build Tools doesn't have 4.6.2 .NET SDK and what actually gets installed is 4.8
 @rem NOTE: Microsoft.NetCore.Component.SDK only exists for VS2019. And it is actually *needed* only for UE5
 curl --progress-bar -L "https://aka.ms/vs/17/release/vs_buildtools.exe" --output %TEMP%\vs_buildtools.exe || goto :error
 %TEMP%\vs_buildtools.exe --quiet --wait --norestart --nocache ^
@@ -73,7 +72,8 @@ curl --progress-bar -L "https://aka.ms/vs/17/release/vs_buildtools.exe" --output
 	--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 ^
 	--add Microsoft.VisualStudio.Component.Windows10SDK.%WINDOWS_SDK_VERSION% ^
 	--add Microsoft.Net.Component.4.5.TargetingPack ^
-	--add Microsoft.Net.ComponentGroup.4.6.2.DeveloperTools ^
+	--add Microsoft.Net.Component.4.6.2.TargetingPack ^
+	--add Microsoft.Net.ComponentGroup.DevelopmentPrerequisites ^
 	--add Microsoft.NetCore.Component.SDK
 
 python C:\buildtools-exitcode.py %ERRORLEVEL% || goto :error

--- a/ue4docker/infrastructure/BuildConfiguration.py
+++ b/ue4docker/infrastructure/BuildConfiguration.py
@@ -172,7 +172,7 @@ class BuildConfiguration(object):
         )
         parser.add_argument(
             "--visual-studio",
-            default=VisualStudio.VS2022,
+            default=VisualStudio.VS2019,
             choices=VisualStudio.BuildNumbers.keys(),
             help="Specify Visual Studio Build Tools version to use for Windows containers",
         )

--- a/ue4docker/infrastructure/BuildConfiguration.py
+++ b/ue4docker/infrastructure/BuildConfiguration.py
@@ -172,7 +172,7 @@ class BuildConfiguration(object):
         )
         parser.add_argument(
             "--visual-studio",
-            default=VisualStudio.VS2019,
+            default=VisualStudio.VS2017,
             choices=VisualStudio.BuildNumbers.keys(),
             help="Specify Visual Studio Build Tools version to use for Windows containers",
         )

--- a/ue4docker/infrastructure/BuildConfiguration.py
+++ b/ue4docker/infrastructure/BuildConfiguration.py
@@ -43,10 +43,12 @@ UNREAL_ENGINE_RELEASE_CHANGELISTS = {
 class VisualStudio(object):
     VS2017 = "2017"
     VS2019 = "2019"
+    VS2022 = "2022"
 
     BuildNumbers = {
         VS2017: "15",
         VS2019: "16",
+        VS2022: "17",
     }
 
     MinSupportedUnreal = {
@@ -55,7 +57,8 @@ class VisualStudio(object):
         #
         # Unreal Engine 4.25 is the first that works with .NET SDK 4.7+
         # See https://github.com/EpicGames/UnrealEngine/commit/5256eedbdef30212ab69fdf4c09e898098959683
-        VS2019: semver.VersionInfo(4, 25)
+        VS2019: semver.VersionInfo(4, 25),
+        VS2022: semver.VersionInfo(4, 25),
     }
 
 
@@ -169,7 +172,7 @@ class BuildConfiguration(object):
         )
         parser.add_argument(
             "--visual-studio",
-            default=VisualStudio.VS2017,
+            default=VisualStudio.VS2022,
             choices=VisualStudio.BuildNumbers.keys(),
             help="Specify Visual Studio Build Tools version to use for Windows containers",
         )

--- a/ue4docker/infrastructure/BuildConfiguration.py
+++ b/ue4docker/infrastructure/BuildConfiguration.py
@@ -58,7 +58,8 @@ class VisualStudio(object):
         # Unreal Engine 4.25 is the first that works with .NET SDK 4.7+
         # See https://github.com/EpicGames/UnrealEngine/commit/5256eedbdef30212ab69fdf4c09e898098959683
         VS2019: semver.VersionInfo(4, 25),
-        VS2022: semver.VersionInfo(4, 25),
+
+        VS2022: semver.VersionInfo(4, 27),
     }
 
 


### PR DESCRIPTION
RunUAT will print the following message with 4.27.2 (and older), but it still works. UE 5.0 (presumably) updated that version check as they increment it with every release if there is a newer compatible VS version.

> Detected compiler newer than Visual Studio 2019, please update min version checking in WindowsPlatformCompilerSetup.h

I also defaulted it to VS2019. VS2017 is pretty old and certain C++17 features are not well supported - this comes into play if you are building 3rd party things along with your Unreal project. Wanted to default to VS2022, but VS2019 feels safer at this time.

Minimal supported Unreal version for VS2022 might be higher, but I can't really test all older Unreal versions at this time. Since VS2019 to VS2022 generally worked without issue, I am **assuming** it is compatible to the same range of engines backwards as VS2019 is.

I didn't test the full build yet.

---

As a side note, RunUAT still needs to be used with `-VS2019` argument (eg. `ue4 package -VS2019`) to pick up VS2022 and prevent it from complaining about missing VS2017. That is something that should be documented in ue4cli if this is confirmed working.