### PR TITLE
Adjust UBT pre-build warmup so it is compatible with UE >= 5.0.2

### DIFF
--- a/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile
@@ -30,13 +30,10 @@ COPY patch-build-graph.py /tmp/patch-build-graph.py
 RUN python3 /tmp/patch-build-graph.py /home/ue4/UnrealEngine/Engine/Build/InstalledEngineBuild.xml /home/ue4/UnrealEngine/Engine/Build/Build.version
 {% endif %}
 
-{% if (not disable_all_patches) and (not disable_ubt_prebuild) %}
-# For versions of the Unreal Engine prior to 5.0 when the C# build tools migrated to .NET Core:
 # Ensure UBT is built before we create the Installed Build, since Build.sh explicitly sets the
 # target .NET Framework version, whereas InstalledEngineBuild.xml just uses the system default,
 # which can result in errors when running the built UBT due to the wrong version being targeted
-RUN ./Engine/Build/BatchFiles/Linux/Build.sh UnrealHeaderTool Linux Development -SkipBuild
-{% endif %}
+RUN ./Engine/Build/BatchFiles/Linux/Build.sh UnrealHeaderTool Linux Development -SkipBuild -buildubt
 
 # Create an Installed Build of the Engine
 WORKDIR /home/ue4/UnrealEngine


### PR DESCRIPTION
This is a follow-up to 7ecc98ac0ae351d36ff8aea8b1542f789c038920

This change accounts for `Engine/Build/BatchFiles/Linux/Build.sh` changes in https://github.com/EpicGames/UnrealEngine/commit/6bfd4d435dd6ca51c4d2b5819d5ed2f7e1dd9a12

Motivation: we don't want to force all UE5 users to define `disable_ubt_prebuild` option.

----

@adamrehn FYI