### PR TITLE
[Windows] Remove engine intermediate engine build products before committing ue4-minimal builder image

### DIFF
--- a/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
@@ -34,7 +34,8 @@ RUN .\Engine\Build\BatchFiles\RunUAT.bat BuildGraph `
     -set:HostPlatformOnly=true `
     -set:WithDDC={% if excluded_components.ddc == true %}false{% else %}true{% endif %} `
     {{ buildgraph_args }} && `
-	(if exist C:\UnrealEngine\LocalBuilds\InstalledDDC rmdir /s /q C:\UnrealEngine\LocalBuilds\InstalledDDC)
+	(if exist C:\UnrealEngine\LocalBuilds\InstalledDDC rmdir /s /q C:\UnrealEngine\LocalBuilds\InstalledDDC) && `
+	rmdir /s /q C:\UnrealEngine\Engine
 
 # Split out components (DDC, debug symbols, template projects) so they can be copied into the final container image as separate filesystem layers
 COPY split-components.py C:\split-components.py


### PR DESCRIPTION
These products are not used after build step, but they take massive amounts of disk space: up to 350GBs for multi-platform (Win64+PS4+PS5+XB1+XSX) engine build

To make matters even worse, current Docker image commit algorithm on Windows additionally uses x2 of resulting image size on disk.