### PR TITLE
Add labels, so it is possible to identify layers with engine

### DIFF
--- a/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-minimal/windows/Dockerfile
@@ -55,16 +55,33 @@ FROM ${NAMESPACE}/ue4-build-prerequisites:${PREREQS_TAG}
 {% endif %}
 
 # Copy the Installed Build files from the builder image
+
+{% if not disable_labels %}
+LABEL com.adamrehn.ue4-docker.layer.binaries
+{% endif %}
 COPY --from=builder C:\UnrealEngine\LocalBuilds\Engine\Windows C:\UnrealEngine
+
 {% if excluded_components.ddc == false %}
+{% if not disable_labels %}
+LABEL com.adamrehn.ue4-docker.layer.ddc
+{% endif %}
 COPY --from=builder C:\UnrealEngine\Components\DDC C:\UnrealEngine
 {% endif %}
+
 {% if excluded_components.debug == false %}
+{% if not disable_labels %}
+LABEL com.adamrehn.ue4-docker.layer.debug
+{% endif %}
 COPY --from=builder C:\UnrealEngine\Components\DebugSymbols C:\UnrealEngine
 {% endif %}
+
 {% if excluded_components.templates == false %}
+{% if not disable_labels %}
+LABEL com.adamrehn.ue4-docker.layer.templates
+{% endif %}
 COPY --from=builder C:\UnrealEngine\Components\TemplatesAndSamples C:\UnrealEngine
 {% endif %}
+
 WORKDIR C:\UnrealEngine
 
 {% if not disable_labels %}


### PR DESCRIPTION
Intended scenario:
Suppose there is a tool that downloads and extracts engine from Docker image.
Such tool would like to only download relevant layers.
It doesn't want to download build-prerequisites layer.
It might not want to download debug layer.

With labels, a tool can analyze image manifest and only pick those engine layers that it needs.