### PR TITLE
Avoid downloading unneeded dependencies on Linux

### DIFF
--- a/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
+++ b/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
@@ -96,7 +96,11 @@ RUN python3 /tmp/patch-broken-releases.py /home/ue4/UnrealEngine $VERBOSE_OUTPUT
 # When running with BuildKit, we use a cache mount to cache the dependency data in `.git/ue4-gitdeps` across multiple build invocations
 WORKDIR /home/ue4/UnrealEngine
 RUN --mount=type=cache,target=/home/ue4/UnrealEngine/.git/ue4-gitdeps,uid=1000,gid=1000 sudo apt-get update && \
-	./Setup.sh && \
+	./Setup.sh \
+		--exclude=Android \
+		--exclude=Mac \
+		--exclude=Win32 \
+		--exclude=Win64 && \
 	sudo rm -rf /var/lib/apt/lists/*
 
 {% else %}
@@ -104,7 +108,11 @@ RUN --mount=type=cache,target=/home/ue4/UnrealEngine/.git/ue4-gitdeps,uid=1000,g
 # When running without BuildKit, we use the `-no-cache` flag to disable caching of dependency data in `.git/ue4-gitdeps`, saving disk space
 WORKDIR /home/ue4/UnrealEngine
 RUN sudo apt-get update && \
-	./Setup.sh -no-cache && \
+	./Setup.sh -no-cache \
+		--exclude=Android \
+		--exclude=Mac \
+		--exclude=Win32 \
+		--exclude=Win64 && \
 	sudo rm -rf /var/lib/apt/lists/*
 
 {% endif %}


### PR DESCRIPTION
Before this commit, `ue4-docker build 5.0.3 --target=minimal`:

* `ue4-source`: 67.2GB
* `ue4-minimal`: 54.5GB

After this commit, `ue4-docker build 5.0.3 --target=minimal`:

* `ue4-source`: 47.5GB
* `ue4-minimal`: 47GB