### PR TITLE
feat: ability to specify docker org for baseimg

### DIFF
--- a/ue4docker/infrastructure/BuildConfiguration.py
+++ b/ue4docker/infrastructure/BuildConfiguration.py
@@ -14,9 +14,11 @@ DEFAULT_GIT_REPO = "https://github.com/EpicGames/UnrealEngine.git"
 
 # The base images for Linux containers
 LINUX_BASE_IMAGES = {
-    "opengl": "nvidia/opengl:1.0-glvnd-devel-{ubuntu}",
-    "cudagl": "nvidia/cudagl:{cuda}-devel-{ubuntu}",
+    "opengl": "{org}/opengl:1.0-glvnd-devel-{ubuntu}",
+    "cudagl": "{org}/cudagl:{cuda}-devel-{ubuntu}",
 }
+
+DEFAULT_BASE_IMG_ORG = "nvidia"
 
 # The default ubuntu base to use
 DEFAULT_LINUX_VERSION = "ubuntu18.04"
@@ -196,6 +198,11 @@ class BuildConfiguration(object):
             "-isolation",
             default=None,
             help="Set the isolation mode to use for Windows containers (process or hyperv)",
+        )
+        parser.add_argument(
+            "-baseorg",
+            default=DEFAULT_BASE_IMG_ORG,
+            help=f"The Docker organisation to pull the base images from (defaults to '{DEFAULT_BASE_IMG_ORG}')",
         )
         parser.add_argument(
             "-basetag",
@@ -666,11 +673,7 @@ class BuildConfiguration(object):
             raise RuntimeError('tag suffix cannot begin with "opengl" or "cudagl".')
 
         # Determine if we are building CUDA-enabled container images
-        self.cuda = None
         if self.args.cuda is not None:
-
-            # Verify that the specified CUDA version is valid
-            self.cuda = self.args.cuda if self.args.cuda != "" else DEFAULT_CUDA_VERSION
             # Use the appropriate base image for the specified CUDA version
             self.baseImage = LINUX_BASE_IMAGES["cudagl"]
             self.prereqsTag = "cudagl{cuda}-{ubuntu}"
@@ -679,7 +682,7 @@ class BuildConfiguration(object):
             self.prereqsTag = "opengl-{ubuntu}"
 
         self.baseImage = self.baseImage.format(
-            cuda=self.args.cuda, ubuntu=self.args.basetag
+            org=self.args.baseorg, cuda=self.args.cuda, ubuntu=self.args.basetag
         )
         self.prereqsTag = self.prereqsTag.format(
             cuda=self.args.cuda, ubuntu=self.args.basetag


### PR DESCRIPTION
At the moment nvidia is being slow at pushing out ubuntu 22.04 cudagl images and we've been forced to create our own. This patch lets users use their own organisation images instead of nvidia's.

This adds a `-baseorg` argument to the build command.