### PR TITLE
feat(vs2022): improve vs2022 support

### DIFF
--- a/ue4docker/infrastructure/BuildConfiguration.py
+++ b/ue4docker/infrastructure/BuildConfiguration.py
@@ -62,9 +62,7 @@ class VisualStudio(object):
         # Unreal Engine 4.25 is the first that works with .NET SDK 4.7+
         # See https://github.com/EpicGames/UnrealEngine/commit/5256eedbdef30212ab69fdf4c09e898098959683
         VS2019: semver.VersionInfo(4, 25),
-        # Even though Epics claimed in 4.27 and 5.0 that they added VS2022 support,
-        # everything up to (including) 5.1.0 fails to build with it due to dependencies on .NET 4.5.
-        VS2022: semver.VersionInfo(5, 1, 1),
+        VS2022: semver.VersionInfo(5, 0, 0),
     }
 
     UnsupportedSince = {VS2017: semver.VersionInfo(5, 0)}


### PR DESCRIPTION
Adds a routine to extract .net 4.5 Targetting Pack for VS2022 from nuget directly.

Adds .net 3.1 RunTime to avoid the following error when packaging (only occurs on packaging) with VS2022

```
Running AutomationTool...
You must install or update .NET to run this application.

App: C:\UnrealEngine\Engine\Binaries\DotNET\AutomationTool\AutomationTool.dll
Architecture: x64
Framework: 'Microsoft.WindowsDesktop.App', version '3.1.0' (x64)
.NET location: C:\Program Files\dotnet\

The following frameworks were found:
  6.0.11 at [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  7.0.0 at [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.WindowsDesktop.App&framework_version=3.1.0&arch=x64&rid=win10-x64
```