### PR TITLE
fix(package): patch filters to exclude hololens due to package error

### DIFF
--- a/ue4docker/dockerfiles/ue4-source/windows/patch-broken-releases.py
+++ b/ue4docker/dockerfiles/ue4-source/windows/patch-broken-releases.py
@@ -53,3 +53,30 @@ if (
             print("PATCHED {}:\n\n{}".format(gitdepsFile, gitdepsXml), file=sys.stderr)
         else:
             print("PATCHED {}".format(gitdepsFile), file=sys.stderr)
+
+
+# Determine if we are building UE 5.1.0
+if (
+    versionDetails["MajorVersion"] == 5
+    and versionDetails["MinorVersion"] == 1
+    and versionDetails["PatchVersion"] == 0
+):
+
+    # Hack InstalledEngineFilters.xml with the changes from CL 23300641
+    # (See: <https://github.com/EpicGames/UnrealEngine/commit/ae9de79b7012fc33df355c8dbfe5096b94545e3c>)
+    buildFile = join(engineRoot, "Engine", "Build", "InstalledEngineFilters.xml")
+    buildXml = readFile(buildFile)
+    if 'HoloLens.Automation.json' not in buildXml:
+
+        buildXml = buildXml.replace(
+            '<Property Name="CopyWin64CsToolsExceptions">',
+            '<Property Name="CopyWin64CsToolsExceptions">\n'
+			+ '            Engine\Saved\CsTools\Engine\Intermediate\ScriptModules\HoloLens.Automation.json\n',
+        )
+
+        writeFile(buildFile, buildXml)
+
+        if verboseOutput == True:
+            print("PATCHED {}:\n\n{}".format(buildFile, buildFile), file=sys.stderr)
+        else:
+            print("PATCHED {}".format(buildFile), file=sys.stderr)

--- a/ue4docker/dockerfiles/ue4-source/windows/patch-broken-releases.py
+++ b/ue4docker/dockerfiles/ue4-source/windows/patch-broken-releases.py
@@ -71,7 +71,7 @@ if (
         buildXml = buildXml.replace(
             '<Property Name="CopyWin64CsToolsExceptions">',
             '<Property Name="CopyWin64CsToolsExceptions">\n'
-			+ '            Engine\Saved\CsTools\Engine\Intermediate\ScriptModules\HoloLens.Automation.json\n',
+            + '            Engine\Saved\CsTools\Engine\Intermediate\ScriptModules\HoloLens.Automation.json\n',
         )
 
         writeFile(buildFile, buildXml)

--- a/ue4docker/dockerfiles/ue4-source/windows/patch-broken-releases.py
+++ b/ue4docker/dockerfiles/ue4-source/windows/patch-broken-releases.py
@@ -66,12 +66,12 @@ if (
     # (See: <https://github.com/EpicGames/UnrealEngine/commit/ae9de79b7012fc33df355c8dbfe5096b94545e3c>)
     buildFile = join(engineRoot, "Engine", "Build", "InstalledEngineFilters.xml")
     buildXml = readFile(buildFile)
-    if 'HoloLens.Automation.json' not in buildXml:
+    if "HoloLens.Automation.json" not in buildXml:
 
         buildXml = buildXml.replace(
             '<Property Name="CopyWin64CsToolsExceptions">',
             '<Property Name="CopyWin64CsToolsExceptions">\n'
-            + '            Engine\Saved\CsTools\Engine\Intermediate\ScriptModules\HoloLens.Automation.json\n',
+            + "            Engine\Saved\CsTools\Engine\Intermediate\ScriptModules\HoloLens.Automation.json\n",
         )
 
         writeFile(buildFile, buildXml)


### PR DESCRIPTION
Packaging in UE 5.1.0 (even outside of UE4-Docker) results in an error

```
Unhandled exception: One or more errors occurred. (Script module "C:\UnrealEngine\Engine\Platforms\Hololens\Binaries\DotNET\AutomationTool\AutomationScripts\Platforms\HoloLens\HoloLens.Automation.dll" not found for record "C:\UnrealEngine\Engine\Intermediate\ScriptModules\HoloLens.Automation.json")
```

The PR to fix this itself doesn't work, but patching `InstalledEngineFilters.xml` instead provide the same workaround.