### PR TITLE
Pins versions of conan to < v2 in the ue4-full images

### DIFF
--- a/src/ue4docker/dockerfiles/ue4-full/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-full/linux/Dockerfile
@@ -1,5 +1,6 @@
 ARG UE4CLI_VERSION="ue4cli>=0.0.45"
 ARG CONAN_UE4CLI_VERSION="conan-ue4cli>=0.0.27"
+ARG CONAN_VERSION="conan>=1.59.0,<2"
 {% if combine %}
 FROM source as conan
 {% else %}
@@ -10,11 +11,12 @@ FROM ${NAMESPACE}/ue4-source:${TAG}-${PREREQS_TAG} AS conan
 {% endif %}
 ARG UE4CLI_VERSION
 ARG CONAN_UE4CLI_VERSION
+ARG CONAN_VERSION
 
 # Install ue4cli and conan-ue4cli
 USER root
 RUN pip3 install --upgrade pip setuptools wheel
-RUN pip3 install "$UE4CLI_VERSION" "$CONAN_UE4CLI_VERSION"
+RUN pip3 install "$CONAN_VERSION" "$UE4CLI_VERSION" "$CONAN_UE4CLI_VERSION"
 USER ue4
 
 # Extract the third-party library details from UBT
@@ -29,6 +31,7 @@ FROM ${NAMESPACE}/ue4-minimal:${TAG}-${PREREQS_TAG}
 {% endif %}
 ARG UE4CLI_VERSION
 ARG CONAN_UE4CLI_VERSION
+ARG CONAN_VERSION
 
 # Install CMake, ue4cli, conan-ue4cli, and ue4-ci-helpers
 USER root

--- a/src/ue4docker/dockerfiles/ue4-full/windows/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-full/windows/Dockerfile
@@ -1,6 +1,7 @@
 # escape=`
 ARG UE4CLI_VERSION="ue4cli>=0.0.45"
 ARG CONAN_UE4CLI_VERSION="conan-ue4cli>=0.0.27"
+ARG CONAN_VERSION="conan>=1.59.0,<2"
 {% if combine %}
 FROM source as conan
 {% else %}
@@ -11,10 +12,11 @@ FROM ${NAMESPACE}/ue4-source:${TAG}-${PREREQS_TAG} AS conan
 {% endif %}
 ARG UE4CLI_VERSION
 ARG CONAN_UE4CLI_VERSION
+ARG CONAN_VERSION
 
 # Install ue4cli and conan-ue4cli
 RUN pip install setuptools wheel --no-warn-script-location
-RUN pip install "%UE4CLI_VERSION%" "%CONAN_UE4CLI_VERSION%" --no-warn-script-location
+RUN pip install "%CONAN_VERSION%" "%UE4CLI_VERSION%" "%CONAN_UE4CLI_VERSION%" --no-warn-script-location
 
 # Build UBT, and extract the third-party library details from UBT
 # (Remove the profile base packages to avoid a bug where Windows locks the files and breaks subsequent profile generation)
@@ -30,10 +32,11 @@ FROM ${NAMESPACE}/ue4-minimal:${TAG}-${PREREQS_TAG}
 {% endif %}
 ARG UE4CLI_VERSION
 ARG CONAN_UE4CLI_VERSION
+ARG CONAN_VERSION
 
 # Install ue4cli conan-ue4cli, and ue4-ci-helpers
 RUN pip install setuptools wheel --no-warn-script-location
-RUN pip install "%UE4CLI_VERSION%" "%CONAN_UE4CLI_VERSION%" ue4-ci-helpers --no-warn-script-location
+RUN pip install "%CONAN_VERSION%" "%UE4CLI_VERSION%" "%CONAN_UE4CLI_VERSION%" ue4-ci-helpers --no-warn-script-location
 
 # Explicitly set the configuration directory for ue4cli
 # (This prevents things from breaking when using CI/CD systems that override the $HOME environment variable)


### PR DESCRIPTION
The conan library has some breaking changes in v2
 
This adds a build ARG to the full image and default to forcing the version of conan to <v2 

Test in Linux on ubuntu 22, and in windows on windows server 2022. 

resolves #305