### PR TITLE
Increases size set by setup command

### DIFF
--- a/docs/configuring-linux.adoc
+++ b/docs/configuring-linux.adoc
@@ -9,7 +9,7 @@
 
 - 64-bit version of one of Docker's https://docs.docker.com/install/#supported-platforms[supported Linux distributions] (CentOS 7+, Debian 7.7+, Fedora 26+, Ubuntu 14.04+)
 - Minimum 8GB of RAM
-- Minimum 400GB available disk space for building container images
+- Minimum 800GB available disk space for building container images
 
 == Step 1: Install Docker CE
 

--- a/docs/configuring-macos.adoc
+++ b/docs/configuring-macos.adoc
@@ -13,7 +13,7 @@ Linux containers are unable to use GPU acceleration via the xref:nvidia-docker-p
 - 2010 or newer model Mac hardware
 - macOS 10.10.3 Yosemite or newer
 - Minimum 8GB of RAM
-- Minimum 400GB available disk space for building container images
+- Minimum 800GB available disk space for building container images
 
 == Step 1: Install Docker CE for Mac
 
@@ -48,4 +48,4 @@ sudo pip3 install ue4-docker
 
 == Step 4: Manually configure Docker daemon settings
 
-Use https://docs.docker.com/desktop/mac/#resources[the Advanced section under the Resources tab of the Docker Desktop settings pane] to set the memory allocation for the Moby VM to 8GB and the maximum VM disk image size to 400GB.
+Use https://docs.docker.com/desktop/mac/#resources[the Advanced section under the Resources tab of the Docker Desktop settings pane] to set the memory allocation for the Moby VM to 8GB and the maximum VM disk image size to 800GB.

--- a/docs/configuring-windows-10.adoc
+++ b/docs/configuring-windows-10.adoc
@@ -61,7 +61,7 @@ For building and running Windows containers:
 
 - Configure the Docker daemon to https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers[use Windows containers] rather than Linux containers.
 - Configure the Docker daemon to increase the maximum container disk size from the default 20GB limit by following https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/container-storage#storage-limits[the instructions provided by Microsoft].
-The 120GB limit specified in the instructions is not quite enough, so set a 400GB limit instead. **Be sure to restart the Docker daemon after applying the changes to ensure they take effect.**
+The 120GB limit specified in the instructions is not quite enough, so set an 800GB limit instead. **Be sure to restart the Docker daemon after applying the changes to ensure they take effect.**
 
 WARNING: **The ue4-docker maintainers do not provide support for building and running Linux containers under Windows**, due to the various technical limitations of the Hyper-V and WSL2 backends for Docker Desktop (see https://github.com/adamrehn/ue4-docker/issues/205[this issue] for details of these limitations).
 This functionality is still present in ue4-docker for those who choose to use it, but users are solely responsible for troubleshooting any issues they encounter when doing so.
@@ -70,6 +70,6 @@ For building and running Linux containers:
 
 - Configure the Docker daemon to https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers[use Linux containers] rather than Windows containers.
 
-- **If you are using the Hyper-V backend** then use https://docs.docker.com/desktop/windows/#resources[the Advanced section under the Resources tab of the Docker Desktop settings pane] to set the memory allocation for the Moby VM to 8GB and the maximum VM disk image size to 400GB.
+- **If you are using the Hyper-V backend** then use https://docs.docker.com/desktop/windows/#resources[the Advanced section under the Resources tab of the Docker Desktop settings pane] to set the memory allocation for the Moby VM to 8GB and the maximum VM disk image size to 800GB.
 
-- **If you are using the WSL2 backend** then https://docs.microsoft.com/en-us/windows/wsl/compare-versions#expanding-the-size-of-your-wsl-2-virtual-hard-disk[expand the WSL2 virtual hard disk] to at least 400GB.
+- **If you are using the WSL2 backend** then https://docs.microsoft.com/en-us/windows/wsl/compare-versions#expanding-the-size-of-your-wsl-2-virtual-hard-disk[expand the WSL2 virtual hard disk] to at least 800GB.

--- a/docs/configuring-windows-server.adoc
+++ b/docs/configuring-windows-server.adoc
@@ -67,4 +67,4 @@ To automatically configure the required system settings, run the xref:ue4-docker
 ue4-docker setup
 ----
 
-This will configure the Docker daemon to set the maximum image size to 400GB, create a Windows Firewall rule to allow Docker containers to communicate with the host system (which is required during the build of the xref:available-container-images.adoc#ue4-source[ue4-source] image), and download any required DLL files under Windows Server version 1809 and newer.
+This will configure the Docker daemon to set the maximum image size to 800GB, create a Windows Firewall rule to allow Docker containers to communicate with the host system (which is required during the build of the xref:available-container-images.adoc#ue4-source[ue4-source] image), and download any required DLL files under Windows Server version 1809 and newer.

--- a/docs/ue4-docker-setup.adoc
+++ b/docs/ue4-docker-setup.adoc
@@ -24,7 +24,7 @@ This command will automatically configure a Linux or Windows Server host system 
 
 **Under Windows Server:**
 
-- The Docker daemon will be configured to set the maximum image size for Windows containers to 400GB.
+- The Docker daemon will be configured to set the maximum image size for Windows containers to 800GB.
 - A Windows Firewall rule will be created to allow Docker containers to communicate with the host system, which is required during the build of the xref:available-container-images.adoc#ue4-source[ue4-source] image.
 - Under Windows Server Core version 1809 and newer, any required DLL files will be copied to the host system from the https://hub.docker.com/_/microsoft-windows[full Windows base image].
 Note that the full base image was only introduced in Windows Server version 1809, so this step will not be performed under older versions of Windows Server.

--- a/src/ue4docker/infrastructure/WindowsUtils.py
+++ b/src/ue4docker/infrastructure/WindowsUtils.py
@@ -51,7 +51,7 @@ class WindowsUtils(object):
         """
         Returns the minimum required image size limit (in GB) for Windows containers
         """
-        return 400.0
+        return 800.0
 
     @staticmethod
     def minimumRequiredBuild() -> int:


### PR DESCRIPTION
Increases size set by setup command, and changes the recommend size throughout the documentation. Tested on Windows Server 2022

resolves #307 

Potential issues.  I've changed the docs to recommend 800GB on all OSes, although Windows is the only place where I've explicitly had problems having it set at 400GB.  