### PR TITLE
Update baseimg from nvidia/cudagl to nvidia/cuda

### DIFF
--- a/docs/advanced-build-options.adoc
+++ b/docs/advanced-build-options.adoc
@@ -253,4 +253,4 @@ ue4-docker build RELEASE --cuda=10.0
 {% endhighlight %}
 ----
 
-For a list of supported CUDA versions, see the list of Ubuntu 18.04 image tags for the https://hub.docker.com/r/nvidia/cudagl/[nvidia/cudagl] base image.
+For a list of supported CUDA versions, see the list of Ubuntu 18.04 image tags for the https://hub.docker.com/r/nvidia/cuda/[nvidia/cuda] base image.

--- a/docs/available-container-images.adoc
+++ b/docs/available-container-images.adoc
@@ -26,7 +26,7 @@ You can prevent unwanted images from being built by appending the relevant image
 
 ** `opengl` if CUDA support is not enabled
 
-** `cudaglVERSION` where `VERSION` is the CUDA version if xref:advanced-build-options.adoc#cuda[CUDA support is enabled] (e.g. `cudagl9.2`, `cudagl10.0`, etc.)
+** `cudaVERSION` where `VERSION` is the CUDA version if xref:advanced-build-options.adoc#cuda[CUDA support is enabled] (e.g. `cuda9.2`, `cuda10.0`, etc.)
 
 **Dockerfiles:** https://github.com/adamrehn/ue4-docker/tree/master/ue4docker/dockerfiles/ue4-build-prerequisites/windows/Dockerfile[icon:windows[] Windows] | https://github.com/adamrehn/ue4-docker/tree/master/ue4docker/dockerfiles/ue4-build-prerequisites/linux/Dockerfile[icon:linux[] Linux]
 

--- a/src/ue4docker/infrastructure/BuildConfiguration.py
+++ b/src/ue4docker/infrastructure/BuildConfiguration.py
@@ -14,7 +14,7 @@ DEFAULT_GIT_REPO = "https://github.com/EpicGames/UnrealEngine.git"
 # The base images for Linux containers
 LINUX_BASE_IMAGES = {
     "opengl": "nvidia/opengl:1.0-glvnd-devel-{ubuntu}",
-    "cudagl": "nvidia/cudagl:{cuda}-devel-{ubuntu}",
+    "cuda": "nvidia/cuda:{cuda}-devel-{ubuntu}",
 }
 
 # The default ubuntu base to use
@@ -675,8 +675,8 @@ class BuildConfiguration(object):
 
     def _generateLinuxConfig(self):
         # Verify that any user-specified tag suffix does not collide with our base tags
-        if self.suffix.startswith("opengl") or self.suffix.startswith("cudagl"):
-            raise RuntimeError('tag suffix cannot begin with "opengl" or "cudagl".')
+        if self.suffix.startswith("opengl") or self.suffix.startswith("cuda"):
+            raise RuntimeError('tag suffix cannot begin with "opengl" or "cuda".')
 
         # Determine if we are building CUDA-enabled container images
         self.cuda = None
@@ -684,8 +684,8 @@ class BuildConfiguration(object):
             # Verify that the specified CUDA version is valid
             self.cuda = self.args.cuda if self.args.cuda != "" else DEFAULT_CUDA_VERSION
             # Use the appropriate base image for the specified CUDA version
-            self.baseImage = LINUX_BASE_IMAGES["cudagl"]
-            self.prereqsTag = "cudagl{cuda}-{ubuntu}"
+            self.baseImage = LINUX_BASE_IMAGES["cuda"]
+            self.prereqsTag = "cuda{cuda}-{ubuntu}"
         else:
             self.baseImage = LINUX_BASE_IMAGES["opengl"]
             self.prereqsTag = "opengl-{ubuntu}"


### PR DESCRIPTION
The Docker image `nvidia/cudagl` has been deprecated and replaced with `nvidia/cuda`. The new image has the updated cuda repo signing key so that `sudo apt update` works, but deprecates some tags: see the Announcement section of https://hub.docker.com/r/nvidia/cuda for more details, and #276 for some context.

What I did is replace every instance of `cudagl` with `cuda` in the codebase.

### References
- New cuda image: https://hub.docker.com/r/nvidia/cuda
- Original/deprecated cuda image: https://hub.docker.com/r/nvidia/cudagl