### PR TITLE
Replace workaround for docker-py breakage with a proper fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,15 +23,13 @@ classifiers = [
 ]
 dependencies = [
     "colorama",
-    "docker>=3.0.0",
+    "docker>=6.1.0",
     "humanfriendly",
     "importlib-metadata>=1.0;python_version<'3.8'",
     "Jinja2>=2.11.3",
     "packaging>=19.1",
     "psutil",
     "termcolor",
-    # Workaround for https://github.com/docker/docker-py/issues/3113
-    "urllib3<2",
 ]
 
 [project.urls]


### PR DESCRIPTION
This commit pushes docker-py *a lot* versions forward, but we still keep Python 3.7 as oldest supported.

See e51746f8b852f6f61588dca5531366e92f69e0f5
See https://github.com/docker/docker-py/issues/3113