### PR TITLE
Build minimal image by default

### DIFF
--- a/src/ue4docker/infrastructure/BuildConfiguration.py
+++ b/src/ue4docker/infrastructure/BuildConfiguration.py
@@ -285,9 +285,9 @@ class BuildConfiguration(object):
         using_target_specifier_old = self.args.no_minimal or self.args.no_full
         using_target_specifier_new = self.args.target is not None
 
-        # If we specified nothing, it's the same as specifying `all`
+        # If we specified nothing, it's the same as specifying `minimal`
         if not using_target_specifier_old and not using_target_specifier_new:
-            self.args.target = ["all"]
+            self.args.target = ["minimal"]
         elif using_target_specifier_old and not using_target_specifier_new:
             # Convert these to the new style
             logger.warning(


### PR DESCRIPTION
There are multiple long-standing issues with ue4-full:
* https://github.com/adamrehn/conan-ue4cli/issues/14
* https://github.com/adamrehn/conan-ue4cli/issues/23

If user wants to build ue4-full, they should pass `--target=full` option.