### PR TITLE
Follow Epic's logic for removing debug symbols

### DIFF
--- a/src/ue4docker/dockerfiles/ue4-minimal/windows/split-components.py
+++ b/src/ue4docker/dockerfiles/ue4-minimal/windows/split-components.py
@@ -48,7 +48,7 @@ ddc = [join(rootDir, "Engine", "DerivedDataCache", "Compressed.ddp")]
 extractComponent(rootDir, outputDir, "DDC", "Derived Data Cache (DDC)", ddc)
 
 # Extract debug symbols
-symbolFiles = glob.glob(join(rootDir, "**", "*.pdb"), recursive=True)
+symbolFiles = glob.glob(join(rootDir, "**", "*UnrealEditor*.pdb"), recursive=True)
 extractComponent(rootDir, outputDir, "DebugSymbols", "debug symbols", symbolFiles)
 
 # Extract template projects and samples


### PR DESCRIPTION
There are `pdb` files, not prefaced with `UnrealEngine`, which are expected to be present when creating a shipping build.

*  C:\UnrealEngine\Engine\Binaries\Win64\tbb.pdb
*  C:\UnrealEngine\Engine\Binaries\Win64\tbbmalloc.pdb

/cc @slonopotamus 