### PR TITLE
Reorganize GitHub Actions test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,21 +31,27 @@ jobs:
     strategy:
       matrix:
         include:
-        - { os: ubuntu-20.04,   python: "3.7"  }
-        - { os: ubuntu-20.04,   python: "3.10" }
-        - { os: ubuntu-22.04,   python: "3.10" }
-        - { os: windows-2019,   python: "3.7",  visual-studio: 2017 }
-        - { os: windows-2019,   python: "3.10", visual-studio: 2017 }
-        - { os: windows-2019,   python: "3.7",  visual-studio: 2019 }
-        - { os: windows-2019,   python: "3.10", visual-studio: 2019 }
-        - { os: windows-2019,   python: "3.7",  visual-studio: 2022 }
-        - { os: windows-2019,   python: "3.10", visual-studio: 2022 }
-        - { os: windows-latest, python: "3.7",  visual-studio: 2017 }
-        - { os: windows-latest, python: "3.10", visual-studio: 2017 }
-        - { os: windows-latest, python: "3.7",  visual-studio: 2019 }
-        - { os: windows-latest, python: "3.10", visual-studio: 2019 }
-        - { os: windows-latest, python: "3.7",  visual-studio: 2022 }
-        - { os: windows-latest, python: "3.10", visual-studio: 2022 }
+        # All supported Ubuntu LTS with system python
+        # Be careful when removing EOL versions so that we still test our oldest supported python at least somewhere
+        - { os: ubuntu-20.04, python: "3.8"  }
+        - { os: ubuntu-22.04, python: "3.10" }
+        - { os: ubuntu-24.04, python: "3.12" }
+
+          # All supported Visual Studio on Windows Server 2019
+        - { os: windows-2019, python: "3.12", visual-studio: 2017 }
+        - { os: windows-2019, python: "3.12", visual-studio: 2019 }
+        - { os: windows-2019, python: "3.12", visual-studio: 2022 }
+
+          # All supported Visual Studio on Windows Server 2022
+        - { os: windows-2022, python: "3.12", visual-studio: 2017 }
+        - { os: windows-2022, python: "3.12", visual-studio: 2019 }
+        - { os: windows-2022, python: "3.12", visual-studio: 2022 }
+
+        # All supported Visual Studio on Windows Server 2025
+        # TODO: Waiting for https://github.com/actions/runner-images/issues/10806
+        # - { os: windows-2022, python: "3.12", visual-studio: 2017 }
+        # - { os: windows-2022, python: "3.12", visual-studio: 2019 }
+        # - { os: windows-2022, python: "3.12", visual-studio: 2022 }
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout

--- a/docs/configuring-linux.adoc
+++ b/docs/configuring-linux.adoc
@@ -23,9 +23,9 @@ Follow the official installation instructions from the Docker Documentation for 
 Once Docker is installed, follow the instructions from the https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user[Post-installation steps for Linux] page of the Docker Documentation to allow Docker commands to be run by a non-root user.
 This step is required in order to enable audio support when performing cloud rendering using the NVIDIA Container Toolkit.
 
-== Step 2: Install Python 3.6 or newer
+== Step 2: Install Python 3.8 or newer
 
-WARNING: Note that older versions of these Linux distributions may not have Python 3.6 available in their system repositories by default.
+WARNING: Note that older versions of these Linux distributions may not have Python 3.8 available in their system repositories by default.
 When working with an older distribution it may be necessary to configure community repositories that provide newer versions of Python.
 
 Under CentOS, run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "ue4-docker"
 version = "0.0.115"
 description = "Windows and Linux containers for Unreal Engine"
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 license = { file = "LICENSE" }
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Reorganize GitHub Actions test matrix

* All Ubuntus now run tests with Python matching system one
* Windows builds use latest Python. Even if we break something in older versions, we can just ask users to upgrade
* Add Ubuntu 24.04
* Upgrade latest Python to 3.12
* Bump oldest supported Python from 3.7 to 3.8