### PR TITLE
Build UBT by Directly Calling BuildUBT.sh

### DIFF
--- a/src/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile
@@ -13,7 +13,11 @@ RUN rm -rf /home/ue4/UnrealEngine/.git
 # Ensure UBT is built before we create the Installed Build, since Build.sh explicitly sets the
 # target .NET Framework version, whereas InstalledEngineBuild.xml just uses the system default,
 # which can result in errors when running the built UBT due to the wrong version being targeted
-RUN ./Engine/Build/BatchFiles/BuildUBT.sh
+RUN if [ -f ./Engine/Build/BatchFiles/BuildUBT.sh ]; then \
+		./Engine/Build/BatchFiles/BuildUBT.sh; \
+	else \
+		./Engine/Build/BatchFiles/Linux/Build.sh ShaderCompileWorker Linux Development -SkipBuild -buildubt; \
+	fi
 
 # Create an Installed Build of the Engine
 WORKDIR /home/ue4/UnrealEngine

--- a/src/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile
@@ -13,7 +13,7 @@ RUN rm -rf /home/ue4/UnrealEngine/.git
 # Ensure UBT is built before we create the Installed Build, since Build.sh explicitly sets the
 # target .NET Framework version, whereas InstalledEngineBuild.xml just uses the system default,
 # which can result in errors when running the built UBT due to the wrong version being targeted
-RUN ./Engine/Build/BatchFiles/Linux/Build.sh ShaderCompileWorker Linux Development -SkipBuild -buildubt
+RUN ./Engine/Build/BatchFiles/BuildUBT.sh
 
 # Create an Installed Build of the Engine
 WORKDIR /home/ue4/UnrealEngine


### PR DESCRIPTION
Hi there!

I'm on linux building vanilla 5.6 from source. Passing -buildubt to Build.sh doesn't seem to actually build UBT. However running `Engine/Build/BatchFiles/BuildUBT.sh` builds it fine.

Here's what happens when using Build.sh with -buildubt:
```
 => ERROR [builder 3/9] RUN ./Engine/Build/BatchFiles/Linux/Build.sh ShaderCompileWorker Linux Developm  39.6s
------
 > [builder 3/9] RUN ./Engine/Build/BatchFiles/Linux/Build.sh ShaderCompileWorker Linux Development -SkipBuild -buildubt && echo '' && echo 'RUN directive complete. Docker will now commit the filesystem layer to disk.' && echo 'Note that for large filesystem layers this can take quite some time.' && echo 'Performing filesystem layer commit...' && echo '':
0.170 Setting up bundled DotNet SDK
0.401
0.402 Welcome to .NET 8.0!
0.402 ---------------------
0.402 SDK Version: 8.0.300
0.402
0.402 Telemetry
0.402 ---------
0.402 The .NET tools collect usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
0.402
0.402 Read more about .NET CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry
0.459
0.459 ----------------
0.459 Installed an ASP.NET Core HTTPS development certificate.
0.459 To trust the certificate, view the instructions: https://aka.ms/dotnet-https-linux
0.459
0.459 ----------------
0.459 Write your first app: https://aka.ms/dotnet-hello-world
0.459 Find out what's new: https://aka.ms/dotnet-whats-new
0.459 Explore documentation: https://aka.ms/dotnet-docs
0.459 Report issues and find source on GitHub: https://github.com/dotnet/core
0.459 Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
0.459 --------------------------------------------------------------------------------------
32.08
32.08 Build succeeded.
32.08     0 Warning(s)
32.08     0 Error(s)
32.08
32.08 Time Elapsed 00:00:31.53
32.10 Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll ShaderCompileWorker Linux Development -SkipBuild -buildubt
32.17 Could not execute because the specified command or file was not found.
32.17 Possible reasons for this include:
32.17   * You misspelled a built-in dotnet command.
32.17   * You intended to execute a .NET program, but dotnet-Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll does not exist.
32.17   * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
------

ERROR: failed to build: failed to solve: process "/bin/sh -c ./Engine/Build/BatchFiles/Linux/Build.sh ShaderCompileWorker Linux Development -SkipBuild -buildubt && echo '' && echo 'RUN directive complete. Docker will now commit the filesystem layer to disk.' && echo 'Note that for large filesystem layers this can take quite some time.' && echo 'Performing filesystem layer commit...' && echo ''" did not complete successfully: exit code: 1
[ue4-docker build] Error: failed to build image "adamrehn/ue4-minimal:custom-opengl-ubuntu22.04".
```