### PR TITLE
Update CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,21 +36,15 @@ jobs:
         - { os: ubuntu-22.04, python: "3.10" }
         - { os: ubuntu-24.04, python: "3.12" }
 
-          # All supported Visual Studio on Windows Server 2019
-        - { os: windows-2019, python: "3.12", visual-studio: 2017 }
-        - { os: windows-2019, python: "3.12", visual-studio: 2019 }
-        - { os: windows-2019, python: "3.12", visual-studio: 2022 }
-
           # All supported Visual Studio on Windows Server 2022
         - { os: windows-2022, python: "3.12", visual-studio: 2017 }
         - { os: windows-2022, python: "3.12", visual-studio: 2019 }
         - { os: windows-2022, python: "3.12", visual-studio: 2022 }
 
         # All supported Visual Studio on Windows Server 2025
-        # TODO: Waiting for https://github.com/actions/runner-images/issues/10806
-        # - { os: windows-2022, python: "3.12", visual-studio: 2017 }
-        # - { os: windows-2022, python: "3.12", visual-studio: 2019 }
-        # - { os: windows-2022, python: "3.12", visual-studio: 2022 }
+        - { os: windows-2025, python: "3.12", visual-studio: 2017 }
+        - { os: windows-2025, python: "3.12", visual-studio: 2019 }
+        - { os: windows-2025, python: "3.12", visual-studio: 2022 }
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout

--- a/src/ue4docker/infrastructure/WindowsUtils.py
+++ b/src/ue4docker/infrastructure/WindowsUtils.py
@@ -23,7 +23,8 @@ class WindowsUtils(object):
         19042: "20H2",
         19043: "21H1",
         20348: "ltsc2022",
-        22000: "ltsc2022",
+        22000: "ltsc2025",
+        26100: "ltsc2025",
     }
 
     _knownTags = list(_knownTagsByBuildNumber.values())
@@ -123,6 +124,7 @@ class WindowsUtils(object):
         # TODO: we also need to use Windows Server image when user specifies custom tags, like '10.0.20348.169'
         image = {
             "ltsc2022": "mcr.microsoft.com/windows/server",
+            "ltsc2025": "mcr.microsoft.com/windows/server",
         }.get(basetag, "mcr.microsoft.com/windows")
 
         tag = {


### PR DESCRIPTION
Windows Server 2019 is no longer supported on GitHub Actions: https://github.com/actions/runner-images/issues/12045
Windows Server 2025 is now supported: https://github.com/actions/runner-images/issues/11228