### PR TITLE
Set XDG_CONFIG_HOME to prevent engine config paths breaking when GitHub Actions overrides HOME

### DIFF
--- a/src/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile
@@ -82,6 +82,11 @@ COPY --from=builder --chown=ue4:ue4 /home/ue4/UnrealEngine/Components/TemplatesA
 COPY --from=builder --chown=ue4:ue4 /home/ue4/.config/Epic/UnrealEngine/Install.ini /home/ue4/.config/Epic/UnrealEngine/Install.ini
 WORKDIR /home/ue4/UnrealEngine
 
+# GitHub Actions forcibly overrides $HOME and redirects it to a host directory that is bind-mounted at `/github/home`,
+# so we need to explicitly set XDG_CONFIG_HOME to ensure this does not bypass our engine config files and break things
+# (see: <https://github.com/actions/runner/issues/863>)
+ENV XDG_CONFIG_HOME=/home/ue4/.config
+
 {% if not disable_labels %}
 # Add labels to the built image to identify which components (if any) were excluded from the build that it contains
 LABEL com.adamrehn.ue4-docker.excluded.ddc={% if excluded_components.ddc == true %}1{% else %}0{% endif %} 


### PR DESCRIPTION
A user recently reported that they were running into a strange build error when attempting to compile plugins inside the official Unreal Engine 5.6.0 development container image ([whose Dockerfile is generated by ue4-docker](https://github.com/EpicGames/UnrealEngine/blob/5.6.0-release/Engine/Extras/Containers/Dockerfiles/linux/generate.sh)) as part of a GitHub Actions workflow. The error they were encountering looked like this:

```
Precompiled rules assembly '/home/ue4/UnrealEngine/Engine/Source/Epic/UnrealEngine/Intermediate/Build/BuildRules/MarketplaceRules.dll' does not exist.
```

The file `MarketplaceRules.dll` is a .NET assembly that is generated programmatically by UBT in the function [RulesCompiler.CreateMarketplaceRulesAssembly()](https://github.com/EpicGames/UnrealEngine/blob/5.6.0-release/Engine/Source/Programs/UnrealBuildTool/System/RulesCompiler.cs#L200-L230) and stored in the [writable engine directory](https://github.com/EpicGames/UnrealEngine/blob/5.6.0-release/Engine/Source/Programs/Shared/EpicGames.Build/Unreal.cs#L187-L191), which for an Installed Build should resolve to `~/.config/Epic/UnrealEngine`. When manually running the build in the same container image outside of GitHub Actions, the assembly was successfully generated in the correct location:

```
/home/ue4/.config/Epic/UnrealEngine/Intermediate/Build/BuildRules/MarketplaceRules.dll
```

After a little bit of digging, I discovered that **GitHub Actions [forcibly overrides the HOME environment variable when running Linux containers](https://github.com/actions/runner/issues/863), redirecting it to a host directory that is bind-mounted at `/github/home`.** The bind-mounted home directory is empty and does not contain a `.config` subdirectory, which evidently leads the .NET runtime to [report an empty string for `Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)`](https://github.com/dotnet/runtime/issues/69449) when it checks that the directory exists. As a result, UBT ends up resolving the writable engine directory with respect to the current working directory (in this case, `/home/ue4/UnrealEngine/Engine/Source`), leading to the incorrect path observed in the error message above.

I've realised that there are also other adverse side effects in addition to the build error the user encountered. After we create the Installed Build of the engine, we [run UnrealVersionSelector](https://github.com/adamrehn/ue4-docker/blob/e0775a2405805add4110836f9f08fe775a4d9dcf/src/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile#L37-L41) to populate `~/.config/Epic/UnrealEngine/Install.ini` and then [copy the INI file to the final image](https://github.com/adamrehn/ue4-docker/blob/e0775a2405805add4110836f9f08fe775a4d9dcf/src/ue4docker/dockerfiles/ue4-minimal/linux/Dockerfile#L81-L82) to ensure it can be found by any tooling that relies on this file to identify the version and installation path of the engine. The redirected home folder will bypass this completely, resulting in these tools searching in the wrong location.

Fortunately, the fix for this is pretty straightforward: we simply need to set the `XDG_CONFIG_HOME` environment variable to point to `/home/ue4/.config`. This will take precedence over the default search path of `$HOME/.config` and ensure that applications look in the correct location for engine-related configuration files, without interfering with the home folder redirection that GitHub Actions presumably relies upon.