### PR TITLE
patch linux older ue with CDN gitdeps.xml matching release

### DIFF
--- a/src/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
@@ -87,7 +87,9 @@ ARG VERBOSE_OUTPUT=0
 # Apply our bugfix patches to broken Engine releases
 # (Make sure we do this before the post-clone setup steps are run)
 COPY --chown=ue4:ue4 patch-broken-releases.py /tmp/patch-broken-releases.py
-RUN python3 /tmp/patch-broken-releases.py /home/ue4/UnrealEngine $VERBOSE_OUTPUT
+RUN --mount=type=secret,id=password,env=GITPASS,uid=1000,required \
+	sudo apt-get update && sudo apt-get install -y --no-install-recommends python3-requests && sudo rm -rf /var/lib/apt/lists/* \
+	&& python3 /tmp/patch-broken-releases.py /home/ue4/UnrealEngine $VERBOSE_OUTPUT
 {% endif %}
 
 # Run post-clone setup steps, ensuring our package lists are up to date since Setup.sh doesn't call `apt-get update`


### PR DESCRIPTION
unmerged PR #320 by @slonopotamus failed with authentication. This I think gets past it, but I only have run it on 4.27.2 under Linux (and in files using ubuntu24 to come in a separate PR)
Apologies this is only in Linux. maintainers allowed to edit
Black ran on file.

Note, this may also remove the need for https://github.com/adamrehn/ue4-docker/blob/master/test-suite/test-ue-releases.py#L28