### PR TITLE
Ubuntu24 support

### DIFF
--- a/src/ue4docker/dockerfiles/ue4-build-prerequisites/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-build-prerequisites/linux/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && \
 	else \
 	    LIBASOUND2="libasound2"; \
 	fi && apt-get install -y --no-install-recommends \
-			$LIBASOUND2
+			$LIBASOUND2 \
 			libatk1.0-0 \
 			libatk-bridge2.0-0 \
 			libcairo2 \

--- a/src/ue4docker/dockerfiles/ue4-build-prerequisites/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-build-prerequisites/linux/Dockerfile
@@ -89,7 +89,7 @@ ENV GLIBC_TUNABLES=glibc.rtld.dynamic_sort=2
 RUN echo 'Defaults lecture="never"' >> /etc/sudoers
 
 # Unreal refuses to run as the root user, so create a non-root user with no password and allow them to run commands using sudo
-RUN useradd --create-home --home /home/ue4 --shell /bin/bash --uid 1000 ue4 && \
+RUN useradd --create-home --home /home/ue4 --shell /bin/bash --uid 2000 ue4 && \
 	passwd -d ue4 && \
 	usermod -a -G audio,video,sudo ue4
 USER ue4

--- a/src/ue4docker/dockerfiles/ue4-build-prerequisites/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-build-prerequisites/linux/Dockerfile
@@ -44,8 +44,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install the X11 runtime libraries required by CEF so we can cook Unreal Engine projects that use the WebBrowserWidget plugin
 # (Starting in Unreal Engine 5.0, we need these installed before creating an Installed Build to prevent cooking failures related to loading the Quixel Bridge plugin)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-			libasound2 \
+RUN apt-get update && \
+    OS_NAME=$(grep "^NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"') && \
+    OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"') && \
+	if [ "$OS_NAME" = "Ubuntu" ] && dpkg --compare-versions "$OS_VERSION" ge "24.04"; then \
+	    LIBASOUND2="libasound2t64"; \
+	else \
+	    LIBASOUND2="libasound2"; \
+	fi && apt-get install -y --no-install-recommends \
+			$LIBASOUND2
 			libatk1.0-0 \
 			libatk-bridge2.0-0 \
 			libcairo2 \

--- a/src/ue4docker/dockerfiles/ue4-full/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-full/linux/Dockerfile
@@ -15,8 +15,9 @@ ARG CONAN_VERSION
 
 # Install ue4cli and conan-ue4cli
 USER root
-RUN pip3 install --upgrade pip setuptools wheel
-RUN pip3 install "$CONAN_VERSION" "$UE4CLI_VERSION" "$CONAN_UE4CLI_VERSION"
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN pip3 install --ignore-installed --upgrade pip setuptools wheel
+RUN pip3 install --ignore-installed "$CONAN_VERSION" "$UE4CLI_VERSION" "$CONAN_UE4CLI_VERSION"
 USER ue4
 
 # Extract the third-party library details from UBT
@@ -36,8 +37,9 @@ ARG CONAN_VERSION
 # Install CMake, ue4cli, conan-ue4cli, and ue4-ci-helpers
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends cmake
-RUN pip3 install --upgrade pip setuptools wheel
-RUN pip3 install "$CONAN_VERSION" "$UE4CLI_VERSION" "$CONAN_UE4CLI_VERSION" ue4-ci-helpers
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN pip3 install --ignore-installed --upgrade pip setuptools wheel
+RUN pip3 install --ignore-installed "$CONAN_VERSION" "$UE4CLI_VERSION" "$CONAN_UE4CLI_VERSION" ue4-ci-helpers
 USER ue4
 
 # Explicitly set the configuration directory for ue4cli

--- a/src/ue4docker/dockerfiles/ue4-full/linux/pulseaudio-client.conf
+++ b/src/ue4docker/dockerfiles/ue4-full/linux/pulseaudio-client.conf
@@ -1,5 +1,5 @@
 # Connect to the host's PulseAudio server using the mounted UNIX socket
-default-server = unix:/run/user/1000/pulse/native
+default-server = unix:/run/user/2000/pulse/native
 
 # Prevent a PulseAudio server from running in the container
 autospawn = no

--- a/src/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
@@ -87,7 +87,9 @@ ARG VERBOSE_OUTPUT=0
 # Apply our bugfix patches to broken Engine releases
 # (Make sure we do this before the post-clone setup steps are run)
 COPY --chown=ue4:ue4 patch-broken-releases.py /tmp/patch-broken-releases.py
-RUN python3 /tmp/patch-broken-releases.py /home/ue4/UnrealEngine $VERBOSE_OUTPUT
+RUN --mount=type=secret,id=password,env=GITPASS,uid=1000,required \
+	sudo apt-get update && sudo apt-get install -y --no-install-recommends python3-requests && sudo rm -rf /var/lib/apt/lists/* \
+	&& python3 /tmp/patch-broken-releases.py /home/ue4/UnrealEngine $VERBOSE_OUTPUT
 {% endif %}
 
 # Run post-clone setup steps, ensuring our package lists are up to date since Setup.sh doesn't call `apt-get update`

--- a/src/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-source/linux/Dockerfile
@@ -31,8 +31,8 @@ RUN chmod +x /tmp/git-credential-helper-secrets.sh
 # (Note that we include the changelist override value here to ensure any cached source code is invalidated if
 #  the override is modified between runs, which is useful when testing preview versions of the Unreal Engine)
 ARG CHANGELIST
-RUN --mount=type=secret,id=username,uid=1000,required \
-	--mount=type=secret,id=password,uid=1000,required \
+RUN --mount=type=secret,id=username,uid=2000,required \
+	--mount=type=secret,id=password,uid=2000,required \
 	CHANGELIST="$CHANGELIST" \
 	mkdir /home/ue4/UnrealEngine && \
 	cd /home/ue4/UnrealEngine && \
@@ -87,7 +87,7 @@ ARG VERBOSE_OUTPUT=0
 # Apply our bugfix patches to broken Engine releases
 # (Make sure we do this before the post-clone setup steps are run)
 COPY --chown=ue4:ue4 patch-broken-releases.py /tmp/patch-broken-releases.py
-RUN --mount=type=secret,id=password,env=GITPASS,uid=1000,required \
+RUN --mount=type=secret,id=password,env=GITPASS,uid=2000,required \
 	sudo apt-get update && sudo apt-get install -y --no-install-recommends python3-requests && sudo rm -rf /var/lib/apt/lists/* \
 	&& python3 /tmp/patch-broken-releases.py /home/ue4/UnrealEngine $VERBOSE_OUTPUT
 {% endif %}
@@ -102,7 +102,7 @@ RUN mkdir "$UE_GITDEPS"
 
 # When running with BuildKit, we use a cache mount to cache the dependency data across multiple build invocations
 WORKDIR /home/ue4/UnrealEngine
-RUN --mount=type=cache,target=/home/ue4/gitdeps,uid=1000,gid=1000 sudo apt-get update && \
+RUN --mount=type=cache,target=/home/ue4/gitdeps,uid=2000,gid=2000 sudo apt-get update && \
 	./Setup.sh {{ gitdependencies_args }} && \
 	sudo rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This is adding to #386 from older work that previously enabled me to build a 4.27.2 image on ubuntu 24 (ue4-docker build 4.27.2 -basetag=ubuntu24.04 --cuda=12.8.1 ...)

I'm not entirely sure the global pip commit won't break earlier ubuntu. we can add gates like the libasound commit

confirmed this HEAD with minimal build with 5.4 via
``ue4-docker build --ue-version custom:5.4.4 -repo https://github.com/EpicGames/UnrealEngine.git -username $UE4DOCKER_USERNAME -password $UE4DOCKER_PASSWORD -branch 5.4.4-release --target minimal -basetag ubuntu24.04 --cuda=12.8.1 --exclude templates``