### PR TITLE
Install Avahi runtime libraries under Linux

### DIFF
--- a/src/ue4docker/dockerfiles/ue4-build-prerequisites/linux/Dockerfile
+++ b/src/ue4docker/dockerfiles/ue4-build-prerequisites/linux/Dockerfile
@@ -74,6 +74,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 			xkb-data && \
 	rm -rf /var/lib/apt/lists/*
 
+# Install the Avahi runtime libraries required by the NDIMedia plugin
+# (Starting in Unreal Engine 5.7, we need these installed before creating an Installed Build to prevent cooking failures)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+			libavahi-client3 && \
+	rm -rf /var/lib/apt/lists/*
+
 {% if enable_dso_patch %}
 # Install the glibc DSO patch to improve Editor startup times
 RUN add-apt-repository -y ppa:slonopotamus/glibc-dso && \


### PR DESCRIPTION
In the Unreal Engine 5.7.0 release, the [NDIMedia plugin](https://github.com/EpicGames/UnrealEngine/tree/5.7.0-release/Engine/Plugins/Media/NDIMedia) has evidently introduced a dependency on the Avahi runtime libraries under Linux.

As can be seen in [this commit](https://github.com/EpicGames/UnrealEngine/commit/4137cc30bfc170e1824c049c2acf61ace8c458a7) that added support for Linux and macOS, the plugin now ships with a shared library named `libndi.so.6` and dynamically loads it at runtime. Examining the dependencies of that library outside of a container shows the following:

```
$ ldd libndi.so.6 
	linux-vdso.so.1 (0x000078e0f3890000)
	libavahi-common.so.3 => /lib/x86_64-linux-gnu/libavahi-common.so.3 (0x000078e0f3864000)
	libavahi-client.so.3 => /lib/x86_64-linux-gnu/libavahi-client.so.3 (0x000078e0f3850000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x000078e0f384b000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000078e0f3754000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x000078e0f374f000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000078e0f1600000)
	/lib64/ld-linux-x86-64.so.2 (0x000078e0f3892000)
	libdbus-1.so.3 => /lib/x86_64-linux-gnu/libdbus-1.so.3 (0x000078e0f36f7000)
	libsystemd.so.0 => /lib/x86_64-linux-gnu/libsystemd.so.0 (0x000078e0f18c1000)
	libcap.so.2 => /lib/x86_64-linux-gnu/libcap.so.2 (0x000078e0f36e9000)
````

The files `libavahi-client.so.3` and `libavahi-common.so.3` are not currently included in our Linux images, which results in cooking failures when creating an Installed Build of the engine. Those libraries are provided by the [libavahi-client3](https://packages.ubuntu.com/jammy/libavahi-client3) and [libavahi-common3](https://packages.ubuntu.com/jammy/libavahi-common3) packages, respectively, although libavahi-client3 has a dependency on libavahi-common3 so simply installing libavahi-client3 is sufficient to pull in both libraries.